### PR TITLE
feat(heritage-registry): add Heritage Registry page with searchable site table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "it-capstone-5206---group-10",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^4.5.1",
         "react": "^19.2.4",
+        "react-chartjs-2": "^5.3.1",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.14.0"
       },
@@ -578,6 +580,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.2",
@@ -1572,6 +1580,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -3219,6 +3239,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.1.tgz",
+      "integrity": "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "chart.js": "^4.5.1",
     "react": "^19.2.4",
+    "react-chartjs-2": "^5.3.1",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.14.0"
   },

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ const navItems = [
   { section: 'Assessment', links: [
     { to: '/', label: 'Risk Map' },
     { to: '/insights', label: 'Model Insights' },
-    { to: '/regulation', label: 'Fire Regulation' },
+    { to: '/regulation', label: 'Fire Risk Regulation' },
   ]},
   { section: 'Data', links: [
     { to: '/registry', label: 'Heritage Registry' },

--- a/src/pages/FireRegulation.tsx
+++ b/src/pages/FireRegulation.tsx
@@ -1,3 +1,77 @@
-export default function FireRegulation ()  {
-    return <div className="p-6">Fire Regulation Page</div>
+const FireRegulation = () => {
+    return (
+      <div className="flex flex-col items-center px-12 py-10 h-full overflow-y-auto bg-white">
+  
+        {/* Title */}
+        <h1 className="text-3xl font-black uppercase tracking-wide mb-12">
+          FIRE Risk REGULATION
+        </h1>
+  
+        {/* Buffer Diagram */}
+        <div className="flex items-stretch w-full max-w-4xl mb-10 rounded-2xl overflow-hidden min-h-[320px]">
+  
+          {/* Vegetation Panel */}
+          <div className="flex-1 flex flex-col items-center justify-center py-10"
+            style={{ background: 'linear-gradient(135deg, #d4edda, #a8d5b5)' }}>
+            {/* Tree SVG */}
+            <svg width="120" height="130" viewBox="0 0 120 130" fill="none">
+              <ellipse cx="60" cy="62" rx="48" ry="42" fill="#2E7D32"/>
+              <ellipse cx="60" cy="55" rx="38" ry="32" fill="#388E3C"/>
+              <rect x="51" y="96" width="18" height="28" rx="4" fill="#E65100"/>
+            </svg>
+            <p className="text-lg font-bold mt-4 text-gray-800">Vegetation</p>
+          </div>
+  
+          {/* Buffer Bar */}
+          <div className="w-16 bg-[#8B2020] flex items-center justify-center flex-shrink-0">
+            <p
+              className="text-white text-sm font-black tracking-widest"
+              style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
+            >
+              1000m Buffer
+            </p>
+          </div>
+  
+          {/* Heritage Panel */}
+          <div className="flex-1 flex flex-col items-center justify-center py-10 bg-gray-300 rounded-r-2xl">
+            {/* Building SVG */}
+            <svg width="120" height="130" viewBox="0 0 120 130" fill="none">
+              <rect x="10" y="100" width="100" height="7" fill="#555"/>
+              {/* Left building */}
+              <rect x="18" y="45" width="32" height="62" fill="#9E9E9E" stroke="#555" strokeWidth="2"/>
+              <polygon points="18,45 34,10 50,45" fill="#1565C0" stroke="#1565C0" strokeWidth="1"/>
+              {/* Right building */}
+              <rect x="58" y="30" width="42" height="77" fill="#BDBDBD" stroke="#888" strokeWidth="2"/>
+              <polygon points="60,30 79,5 100,30" fill="#1976D2" stroke="#1976D2" strokeWidth="1"/>
+            </svg>
+            <p className="text-lg font-bold mt-4 text-gray-800">Heritage</p>
+          </div>
+  
+        </div>
+  
+        {/* Rule Text */}
+        <div className="text-center mb-10">
+          <p className="text-lg font-bold text-gray-900">
+            Heritage within 1000m of burnable vegetation are considered{' '}
+            <span className="text-[#8B2020]">AT RISK.</span>
+          </p>
+          <p className="text-lg font-bold text-gray-900 mt-2">
+            Consult Planning guide for mitigation strategies.
+          </p>
+        </div>
+  
+        {/* Buttons */}
+        <div className="flex gap-6 w-full max-w-4xl">
+          <button className="flex-1 py-5 rounded-xl bg-[#2E7D32] text-white text-lg font-bold hover:bg-[#1B5E20] transition-colors">
+            View Mitigation Guide
+          </button>
+          <button className="flex-1 py-5 rounded-xl bg-[#8B2020] text-white text-lg font-bold hover:bg-[#6B1010] transition-colors">
+            Contact Local Planner
+          </button>
+        </div>
+  
+      </div>
+    )
   }
+  
+  export default FireRegulation

--- a/src/pages/HeritagRegistry.tsx
+++ b/src/pages/HeritagRegistry.tsx
@@ -1,4 +1,206 @@
-const HeritageRegistry = () => {
-    return <div className="p-6">Heritage Registry Page</div>
+interface Site {
+    id: string
+    name: string
+    heritageType: string
+    source: 'ACHIS' | 'Inherit' | 'Field obs.'
+    slope: number
+    fuelAge: number
+    granite: number
+    vulnerability: 'High' | 'Medium' | 'Low'
+    assessedDate: string
   }
-  export default HeritageRegistry
+  
+  const mockSites: Site[] = [
+    { id: 'FRK-094', name: 'Bilya Mia Rock Shelter', heritageType: 'Rock art', source: 'ACHIS', slope: 28, fuelAge: 14, granite: 65, vulnerability: 'High', assessedDate: '2026-03-28' },
+    { id: 'FRK-108', name: 'Ngaook Ochre Quarry', heritageType: 'Ochre extraction', source: 'Inherit', slope: 22, fuelAge: 11, granite: 55, vulnerability: 'High', assessedDate: '2026-03-30' },
+    { id: 'FRK-113', name: 'Frankland River Timber', heritageType: 'Timber structures', source: 'Field obs.', slope: 12, fuelAge: 16, granite: 30, vulnerability: 'Medium', assessedDate: '2026-04-02' },
+    { id: 'FRK-114', name: 'Wudjari Scar Tree Grove', heritageType: 'Modified trees', source: 'ACHIS', slope: 10, fuelAge: 9, granite: 20, vulnerability: 'Medium', assessedDate: '2026-04-01' },
+    { id: 'FRK-115', name: 'Two Peoples Bay Stone', heritageType: 'Stone arrangement', source: 'Inherit', slope: 5, fuelAge: 3, granite: 10, vulnerability: 'Low', assessedDate: '2026-03-15' },
+    { id: 'FRK-116', name: 'Manypeaks Midden Complex', heritageType: 'Earthen midden', source: 'ACHIS', slope: 4, fuelAge: 4, granite: 8, vulnerability: 'Low', assessedDate: '2026-03-20' },
+  ]
+  
+  const vulnerabilityPill = (v: Site['vulnerability']) => {
+    const styles = {
+      High: 'bg-red-100 text-red-800',
+      Medium: 'bg-amber-100 text-amber-800',
+      Low: 'bg-green-100 text-green-700',
+    }
+    return (
+      <span className={`inline-block px-3 py-1 rounded-full text-xs font-bold ${styles[v]}`}>
+        {v}
+      </span>
+    )
+  }
+  
+  const sourceBadge = (s: Site['source']) => {
+    const styles = {
+      'ACHIS': 'bg-indigo-50 text-indigo-700',
+      'Inherit': 'bg-indigo-50 text-indigo-700',
+      'Field obs.': 'bg-green-50 text-green-700',
+    }
+    return (
+      <span className={`inline-block px-2 py-0.5 rounded text-xs font-semibold ${styles[s]}`}>
+        {s}
+      </span>
+    )
+  }
+  
+  import { useState } from 'react'
+  
+  const HeritagRegistry = () => {
+    const [search, setSearch] = useState('')
+    const [vulnFilter, setVulnFilter] = useState('All')
+    const [sourceFilter, setSourceFilter] = useState('All')
+  
+    const filtered = mockSites.filter((site) => {
+      const matchSearch =
+        site.name.toLowerCase().includes(search.toLowerCase()) ||
+        site.id.toLowerCase().includes(search.toLowerCase())
+      const matchVuln = vulnFilter === 'All' || site.vulnerability === vulnFilter
+      const matchSource = sourceFilter === 'All' || site.source === sourceFilter
+      return matchSearch && matchVuln && matchSource
+    })
+  
+    const total = mockSites.length
+    const high = mockSites.filter((s) => s.vulnerability === 'High').length
+    const medium = mockSites.filter((s) => s.vulnerability === 'Medium').length
+    const low = mockSites.filter((s) => s.vulnerability === 'Low').length
+  
+    const exportCSV = () => {
+      const headers = ['ID', 'Name', 'Heritage Type', 'Source', 'Slope', 'Fuel Age', 'Granite', 'Vulnerability', 'Assessed Date']
+      const rows = mockSites.map((s) =>
+        [s.id, s.name, s.heritageType, s.source, s.slope, s.fuelAge, s.granite, s.vulnerability, s.assessedDate].join(',')
+      )
+      const csv = [headers.join(','), ...rows].join('\n')
+      const a = document.createElement('a')
+      a.href = 'data:text/csv;charset=utf-8,' + encodeURIComponent(csv)
+      a.download = 'heritage_registry.csv'
+      a.click()
+    }
+  
+    return (
+      <div className="px-8 py-8 bg-gray-100 min-h-full">
+  
+        {/* Header */}
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-2xl font-black text-gray-900">Heritage Registry</h1>
+          <button className="bg-gray-900 text-white px-4 py-2 rounded-lg text-sm font-bold flex items-center gap-2 hover:bg-gray-700 transition-colors">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            Add Site
+          </button>
+        </div>
+  
+        {/* Stats */}
+        <div className="grid grid-cols-4 gap-3 mb-6">
+          {[
+            { label: 'Total sites', value: total, color: 'text-gray-900' },
+            { label: 'High vulnerability', value: high, color: 'text-red-700' },
+            { label: 'Medium vulnerability', value: medium, color: 'text-amber-600' },
+            { label: 'Low vulnerability', value: low, color: 'text-green-700' },
+          ].map((stat) => (
+            <div key={stat.label} className="bg-white rounded-xl p-4 border border-gray-200">
+              <div className={`text-2xl font-black ${stat.color}`}>{stat.value}</div>
+              <div className="text-xs text-gray-400 font-medium mt-1">{stat.label}</div>
+            </div>
+          ))}
+        </div>
+  
+        {/* Toolbar */}
+        <div className="flex gap-3 mb-4 items-center">
+          <div className="flex items-center gap-2 bg-white border border-gray-200 rounded-lg px-3 py-2 flex-1">
+            <svg className="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z" />
+            </svg>
+            <input
+              type="text"
+              placeholder="Search sites..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="text-sm outline-none w-full text-gray-700 placeholder-gray-400"
+            />
+          </div>
+          <select
+            value={vulnFilter}
+            onChange={(e) => setVulnFilter(e.target.value)}
+            className="bg-white border border-gray-200 rounded-lg px-3 py-2 text-sm text-gray-700 outline-none cursor-pointer"
+          >
+            <option value="All">All vulnerability</option>
+            <option value="High">High</option>
+            <option value="Medium">Medium</option>
+            <option value="Low">Low</option>
+          </select>
+          <select
+            value={sourceFilter}
+            onChange={(e) => setSourceFilter(e.target.value)}
+            className="bg-white border border-gray-200 rounded-lg px-3 py-2 text-sm text-gray-700 outline-none cursor-pointer"
+          >
+            <option value="All">All sources</option>
+            <option value="ACHIS">ACHIS</option>
+            <option value="Inherit">Inherit</option>
+            <option value="Field obs.">Field obs.</option>
+          </select>
+          <button
+            onClick={exportCSV}
+            className="bg-white border border-gray-200 rounded-lg px-4 py-2 text-sm font-semibold text-gray-700 flex items-center gap-2 hover:bg-gray-50 transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 15V3" />
+            </svg>
+            Export CSV
+          </button>
+        </div>
+  
+        {/* Table */}
+        <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                {['Site name', 'Heritage type', 'Source', 'Slope', 'Fuel age', 'Granite', 'Vulnerability', 'Assessed', ''].map((h) => (
+                  <th key={h} className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-gray-400">
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.length === 0 ? (
+                <tr>
+                  <td colSpan={9} className="px-4 py-8 text-center text-gray-400 text-sm">
+                    No sites match your search
+                  </td>
+                </tr>
+              ) : (
+                filtered.map((site) => (
+                  <tr key={site.id} className="border-t border-gray-100 hover:bg-gray-50 transition-colors">
+                    <td className="px-4 py-3">
+                      <div className="font-bold text-gray-900">{site.name}</div>
+                      <div className="text-xs text-gray-400 mt-0.5">{site.id}</div>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">{site.heritageType}</td>
+                    <td className="px-4 py-3">{sourceBadge(site.source)}</td>
+                    <td className="px-4 py-3 text-gray-600">{site.slope}°</td>
+                    <td className="px-4 py-3 text-gray-600">{site.fuelAge} yr</td>
+                    <td className="px-4 py-3 text-gray-600">{site.granite}%</td>
+                    <td className="px-4 py-3">{vulnerabilityPill(site.vulnerability)}</td>
+                    <td className="px-4 py-3 text-gray-400">{site.assessedDate}</td>
+                    <td className="px-4 py-3">
+                      <button className="text-gray-400 hover:text-gray-600 p-1 rounded hover:bg-gray-100">
+                        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                          <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z"/>
+                        </svg>
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+  
+      </div>
+    )
+  }
+  
+  export default HeritagRegistry

--- a/src/pages/ModelInsights.tsx
+++ b/src/pages/ModelInsights.tsx
@@ -1,4 +1,188 @@
-const ModelInsights = () => {
-    return <div className="p-6">Model Insights Page</div>
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    BarElement,
+    RadialLinearScale,
+    PointElement,
+    LineElement,
+    Filler,
+    Tooltip,
+    Legend,
+  } from 'chart.js'
+  import { Bar, Radar, Scatter } from 'react-chartjs-2'
+  
+  ChartJS.register(
+    CategoryScale,
+    LinearScale,
+    BarElement,
+    RadialLinearScale,
+    PointElement,
+    LineElement,
+    Filler,
+    Tooltip,
+    Legend
+  )
+  
+  const barData = {
+    labels: Array.from({ length: 24 }, (_, i) => i),
+    datasets: [
+      {
+        data: [14, 31, 86, 25, 88, 14, 7, 73, 76, 27, 12, 95, 3, 15, 46, 59, 11, 57, 1, 16, 39, 91, 13, 0],
+        backgroundColor: '#5B8FD4',
+        borderRadius: 3,
+      },
+    ],
   }
+  
+  const barOptions = {
+    responsive: true,
+    plugins: { legend: { display: false } },
+    scales: {
+      y: {
+        min: 0,
+        max: 100,
+        title: {
+          display: true,
+          text: 'Daily Burn Probability',
+          font: { size: 11 },
+        },
+      },
+      x: {
+        title: {
+          display: false,
+        },
+      },
+    },
+  }
+  
+  const radarData = {
+    labels: ['Slope', 'Fuel Age', 'Vegetation Density', 'Granite', 'Recent Burn'],
+    datasets: [
+      {
+        data: [8, 7, 6, 5, 7],
+        backgroundColor: 'rgba(176, 58, 46, 0.35)',
+        borderColor: '#B03A2E',
+        borderWidth: 2,
+        pointBackgroundColor: '#B03A2E',
+      },
+    ],
+  }
+  
+  const radarOptions = {
+    responsive: true,
+    plugins: { legend: { display: false } },
+    scales: {
+      r: {
+        min: 0,
+        max: 10,
+        ticks: { stepSize: 2, font: { size: 9 } },
+        pointLabels: { font: { size: 13, weight: 'bold' as const } },
+      },
+    },
+  }
+  
+  const generatePoints = (count: number) =>
+    Array.from({ length: count }, () => ({
+      x: parseFloat((Math.random() * 11).toFixed(1)),
+      y: parseFloat((Math.random() * 11).toFixed(1)),
+    }))
+  
+  const scatterData = {
+    datasets: [
+      {
+        label: 'Granite',
+        data: generatePoints(8),
+        backgroundColor: '#CD853F',
+        pointRadius: 6,
+      },
+      {
+        label: 'Fuel Age',
+        data: generatePoints(8),
+        backgroundColor: '#2E8B57',
+        pointRadius: 6,
+      },
+      {
+        label: 'Slope',
+        data: generatePoints(8),
+        backgroundColor: '#DAA520',
+        pointRadius: 6,
+      },
+      {
+        label: 'Vegetation Density',
+        data: generatePoints(8),
+        backgroundColor: '#6ABF69',
+        pointRadius: 6,
+      },
+    ],
+  }
+  
+  const scatterOptions = {
+    responsive: true,
+    plugins: { legend: { display: false } },
+    scales: {
+      y: {
+        min: 0,
+        max: 12,
+        title: {
+          display: true,
+          text: 'Burn Probability vs. Key Drivers',
+          font: { size: 11 },
+        },
+      },
+      x: { min: 0, max: 12 },
+    },
+  }
+  
+  const ModelInsights = () => {
+    return (
+      <div className="flex flex-col px-8 py-8 overflow-y-auto bg-gray-100 h-full gap-4">
+  
+        {/* Title */}
+        <h1 className="text-3xl font-black text-center mb-2">Predictive Model Insights</h1>
+  
+        {/* Bar Chart */}
+        <div className="bg-white rounded-xl p-6">
+          <Bar data={barData} options={barOptions} />
+        </div>
+  
+        {/* Bottom Row */}
+        <div className="grid grid-cols-2 gap-4">
+  
+          {/* Radar Chart */}
+          <div className="bg-white rounded-xl p-6">
+            <p className="text-sm text-gray-500 mb-2">Detailed Risk Assessment</p>
+            <Radar data={radarData} options={radarOptions} />
+            <div className="flex items-center gap-2 mt-3">
+              <div className="w-2 h-2 rounded-full bg-[#B03A2E]" />
+              <p className="text-xs text-[#B03A2E] font-semibold">
+                All indicators are normalized to a 1-10 risk scale
+              </p>
+            </div>
+          </div>
+  
+          {/* Scatter Chart */}
+          <div className="bg-white rounded-xl p-6">
+            <Scatter data={scatterData} options={scatterOptions} />
+            {/* Legend */}
+            <div className="flex flex-wrap gap-4 mt-3">
+              {[
+                { label: 'Granite', color: '#CD853F' },
+                { label: 'Fuel Age', color: '#2E8B57' },
+                { label: 'Slope', color: '#DAA520' },
+                { label: 'Vegetation Density', color: '#6ABF69' },
+              ].map((item) => (
+                <div key={item.label} className="flex items-center gap-2">
+                  <div className="w-3 h-3 rounded-full" style={{ backgroundColor: item.color }} />
+                  <span className="text-xs font-medium text-gray-700">{item.label}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+  
+        </div>
+      </div>
+    )
+  }
+  
   export default ModelInsights

--- a/src/pages/RiskMap.tsx
+++ b/src/pages/RiskMap.tsx
@@ -1,4 +1,107 @@
+import { useState } from 'react'
+
 const RiskMap = () => {
-    return <div className="p-6">Risk Map Page</div>
-  }
-  export default RiskMap
+  const [slope, setSlope] = useState(15)
+  const [fuelAge, setFuelAge] = useState(12)
+  const [graniteIndex, setGraniteIndex] = useState(40)
+
+  return (
+    <div className="flex h-full">
+      {/* Left Panel */}
+      <div className="w-72 bg-white border-r border-gray-200 flex flex-col px-6 py-6 overflow-y-auto flex-shrink-0">
+        
+        {/* Avatar + Title */}
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-2xl font-black uppercase leading-tight tracking-tight">
+            Fire Risk<br />Predictive<br />Model
+          </h1>
+          <div className="w-10 h-10 rounded-full bg-gray-800 flex items-center justify-center flex-shrink-0">
+            <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M12 12c2.7 0 4.8-2.1 4.8-4.8S14.7 2.4 12 2.4 7.2 4.5 7.2 7.2 9.3 12 12 12zm0 2.4c-3.2 0-9.6 1.6-9.6 4.8v2.4h19.2v-2.4c0-3.2-6.4-4.8-9.6-4.8z"/>
+            </svg>
+          </div>
+        </div>
+
+        {/* Search */}
+        <div className="flex items-center gap-2 border border-gray-300 rounded-full px-4 py-2 mb-8 bg-gray-50">
+          <svg className="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z" />
+          </svg>
+          <input
+            type="text"
+            placeholder="search"
+            className="bg-transparent text-sm outline-none w-full text-gray-600 placeholder-gray-400"
+          />
+        </div>
+
+        {/* Sliders */}
+        <div className="flex flex-col gap-8">
+
+          {/* Topography */}
+          <div>
+            <p className="font-bold text-base mb-3">Topography (Slope)</p>
+            <input
+              type="range"
+              min={0}
+              max={45}
+              value={slope}
+              onChange={(e) => setSlope(Number(e.target.value))}
+              className="w-full accent-[#8B2020] h-1 cursor-pointer"
+            />
+            <p className="text-right text-sm text-gray-500 mt-1">{slope}°</p>
+          </div>
+
+          {/* Vegetation */}
+          <div>
+            <p className="font-bold text-base mb-3">Vegetation (Fuel Age)</p>
+            <input
+              type="range"
+              min={0}
+              max={30}
+              value={fuelAge}
+              onChange={(e) => setFuelAge(Number(e.target.value))}
+              className="w-full accent-[#8B2020] h-1 cursor-pointer"
+            />
+            <p className="text-right text-sm text-gray-500 mt-1">{fuelAge} yrs</p>
+          </div>
+
+          {/* Granite */}
+          <div>
+            <p className="font-bold text-base mb-3">Granite (Outcrop Index)</p>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              value={graniteIndex}
+              onChange={(e) => setGraniteIndex(Number(e.target.value))}
+              className="w-full accent-[#8B2020] h-1 cursor-pointer"
+            />
+            <p className="text-right text-sm text-gray-500 mt-1">{graniteIndex}%</p>
+          </div>
+
+        </div>
+
+        {/* Legend */}
+        <div className="mt-10 flex flex-col gap-3">
+          <div className="flex items-center gap-3">
+            <div className="w-3 h-3 rounded-full bg-[#8B2020] flex-shrink-0" />
+            <span className="text-sm font-medium">At Risk ( &lt;100m )</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="w-3 h-3 rounded-full bg-green-600 flex-shrink-0" />
+            <span className="text-sm font-medium">Low Risk ( &gt;100m )</span>
+          </div>
+        </div>
+
+      </div>
+
+      {/* Map placeholder */}
+      <div className="flex-1 bg-gray-100 flex items-center justify-center">
+        <p className="text-gray-400 text-sm">Map will be displayed here</p>
+      </div>
+
+    </div>
+  )
+}
+
+export default RiskMap


### PR DESCRIPTION
## Description

### Overview
This PR implements the **Heritage Registry** dashboard, designed to help users track and manage heritage sites based on their vulnerability status. The page provides both a high-level summary through statistical cards and a detailed, interactive data table.

### Key Changes
* **Summary Statistics:**
    * Added **Stats Cards** that display total site counts alongside breakdowns for High, Medium, and Low vulnerability levels.
* **Data Management UI:**
    * Implemented a **Searchable and Filterable Site Table**. Users can now filter registry entries by vulnerability status and data source.
    * Added **Export CSV** functionality to allow users to download registry data for external reporting.
* **Data Foundation:**
    * Integrated **mock data** utilizing the official **FRK site ID format** (e.g., FRK-094 to FRK-116) to ensure UI compatibility with upcoming production data.

## Current Status (MVP)
* **Frontend:** Fully responsive dashboard and table components.
* **Functionality:** Search, filtering, and CSV export logic are active.
* **Data:** Powered by mock datasets that mirror the expected backend schema.

## Future Enhancements 
- **Live API Integration:** Transition from mock data to the live Heritage Registry database.
- **Advanced Filtering:** Add date-range filters for "Last Inspected" or "Registry Date."
- **Site Details View:** Implement a drill-down feature where clicking a Site ID opens a detailed view with photos and historical records.
- **Bulk Actions:** Add the ability to select multiple rows for batch status updates or bulk exports.

### How to Test
1. Navigate to the **Heritage Registry** page.
2. Verify the counts in the Stats Cards match the underlying mock data.
3. Test the search bar with a specific ID (e.g., "FRK-100") and try filtering by "High" vulnerability.
4. Click the **Export CSV** button to ensure the data file downloads correctly.