### PR TITLE
test: add app and sidebar navigation tests

### DIFF
--- a/tests/frontend/app.test.tsx
+++ b/tests/frontend/app.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import App from '../../src/App'
+
+describe('App', () => {
+  it('renders the main frontend shell with the default Risk Map page', () => {
+    const { container } = render(<App />)
+    const sidebar = container.querySelector('aside')
+
+    expect(sidebar).not.toBeNull()
+    expect(sidebar).toHaveTextContent(/Fire Vulnerability\s*Assessment Tool/)
+    expect(screen.getByText('Risk Map')).toBeInTheDocument()
+    expect(screen.getByText('Map will be displayed here')).toBeInTheDocument()
+  })
+})

--- a/tests/frontend/sidebar.test.tsx
+++ b/tests/frontend/sidebar.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import Sidebar from '../../src/components/layout/Sidebar'
+
+describe('Sidebar', () => {
+  it('renders the project branding and all primary navigation links', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>
+    )
+    const sidebar = container.querySelector('aside')
+
+    expect(sidebar).not.toBeNull()
+    expect(sidebar).toHaveTextContent(/Fire Vulnerability\s*Assessment Tool/)
+    expect(screen.getByText('Franklin District · WA')).toBeInTheDocument()
+
+    expect(screen.getByRole('link', { name: 'Risk Map' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Model Insights' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Fire Risk Regulation' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Heritage Registry' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Site Assessment' })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
This PR adds the first page-level frontend tests on top of the frontend testing setup already introduced.

## What was added
- Added `tests/frontend/app.test.tsx`
- Added `tests/frontend/sidebar.test.tsx`

## What is being tested
- The main App renders successfully
- The default frontend shell is displayed
- The Sidebar renders correctly
- The primary navigation links are present:
  - Risk Map
  - Model Insights
  - Fire Risk Regulation
  - Heritage Registry
  - Site Assessment
- The default Risk Map page content is visible

## Why
This PR establishes a baseline for the current `main` frontend before future Risk Map integration. It helps ensure that the app shell and navigation structure remain stable as the project evolves.

## Validation
- Ran `npm test`
- All tests passed successfully (`3 passed`)

## Scope
This PR only adds App and Sidebar navigation tests. It does not yet test the real integrated map functionality.