### PR TITLE
refactor(ui): standardise app terminology + remove Wind factor (#15, #24)

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -52,7 +52,7 @@ const Sidebar = () => {
 
       {/* Footer */}
       <div className="px-4 py-3 border-t border-[#2A2A2A] text-[11px] text-gray-600">
-        Franklin District · FRK<br />v1.0 MVP
+        Franklin District · FRK<br />v1.0 Pilot
       </div>
     </aside>
   )

--- a/src/pages/HeritagRegistry.tsx
+++ b/src/pages/HeritagRegistry.tsx
@@ -1,22 +1,25 @@
+// NBIC Bushfire Fuel Classification — see "Fuel type attribute table" data source.
+type FuelType = 'Forest' | 'Woodland' | 'Shrubland' | 'Heath' | 'Mallee' | 'Grassland'
+
 interface Site {
     id: string
     name: string
     heritageType: string
     source: 'ACHIS' | 'Inherit' | 'Field obs.'
     slope: number
-    fuelAge: number
+    fuelType: FuelType
     granite: number
     vulnerability: 'High' | 'Medium' | 'Low'
     assessedDate: string
   }
-  
+
   const mockSites: Site[] = [
-    { id: 'FRK-094', name: 'Bilya Mia Rock Shelter', heritageType: 'Rock art', source: 'ACHIS', slope: 28, fuelAge: 14, granite: 65, vulnerability: 'High', assessedDate: '2026-03-28' },
-    { id: 'FRK-108', name: 'Ngaook Ochre Quarry', heritageType: 'Ochre extraction', source: 'Inherit', slope: 22, fuelAge: 11, granite: 55, vulnerability: 'High', assessedDate: '2026-03-30' },
-    { id: 'FRK-113', name: 'Frankland River Timber', heritageType: 'Timber structures', source: 'Field obs.', slope: 12, fuelAge: 16, granite: 30, vulnerability: 'Medium', assessedDate: '2026-04-02' },
-    { id: 'FRK-114', name: 'Wudjari Scar Tree Grove', heritageType: 'Modified trees', source: 'ACHIS', slope: 10, fuelAge: 9, granite: 20, vulnerability: 'Medium', assessedDate: '2026-04-01' },
-    { id: 'FRK-115', name: 'Two Peoples Bay Stone', heritageType: 'Stone arrangement', source: 'Inherit', slope: 5, fuelAge: 3, granite: 10, vulnerability: 'Low', assessedDate: '2026-03-15' },
-    { id: 'FRK-116', name: 'Manypeaks Midden Complex', heritageType: 'Earthen midden', source: 'ACHIS', slope: 4, fuelAge: 4, granite: 8, vulnerability: 'Low', assessedDate: '2026-03-20' },
+    { id: 'FRK-094', name: 'Bilya Mia Rock Shelter', heritageType: 'Rock art', source: 'ACHIS', slope: 28, fuelType: 'Forest', granite: 65, vulnerability: 'High', assessedDate: '2026-03-28' },
+    { id: 'FRK-108', name: 'Ngaook Ochre Quarry', heritageType: 'Ochre extraction', source: 'Inherit', slope: 22, fuelType: 'Shrubland', granite: 55, vulnerability: 'High', assessedDate: '2026-03-30' },
+    { id: 'FRK-113', name: 'Frankland River Timber', heritageType: 'Timber structures', source: 'Field obs.', slope: 12, fuelType: 'Forest', granite: 30, vulnerability: 'Medium', assessedDate: '2026-04-02' },
+    { id: 'FRK-114', name: 'Wudjari Scar Tree Grove', heritageType: 'Modified trees', source: 'ACHIS', slope: 10, fuelType: 'Woodland', granite: 20, vulnerability: 'Medium', assessedDate: '2026-04-01' },
+    { id: 'FRK-115', name: 'Two Peoples Bay Stone', heritageType: 'Stone arrangement', source: 'Inherit', slope: 5, fuelType: 'Grassland', granite: 10, vulnerability: 'Low', assessedDate: '2026-03-15' },
+    { id: 'FRK-116', name: 'Manypeaks Midden Complex', heritageType: 'Earthen midden', source: 'ACHIS', slope: 4, fuelType: 'Grassland', granite: 8, vulnerability: 'Low', assessedDate: '2026-03-20' },
   ]
   
   const vulnerabilityPill = (v: Site['vulnerability']) => {
@@ -67,9 +70,9 @@ interface Site {
     const low = mockSites.filter((s) => s.vulnerability === 'Low').length
   
     const exportCSV = () => {
-      const headers = ['ID', 'Name', 'Heritage Type', 'Source', 'Slope', 'Fuel Age', 'Granite', 'Vulnerability', 'Assessed Date']
+      const headers = ['ID', 'Name', 'Heritage Type', 'Source', 'Slope', 'Fuel Type', 'Granite Influence', 'Vulnerability', 'Assessed Date']
       const rows = mockSites.map((s) =>
-        [s.id, s.name, s.heritageType, s.source, s.slope, s.fuelAge, s.granite, s.vulnerability, s.assessedDate].join(',')
+        [s.id, s.name, s.heritageType, s.source, s.slope, s.fuelType, s.granite, s.vulnerability, s.assessedDate].join(',')
       )
       const csv = [headers.join(','), ...rows].join('\n')
       const a = document.createElement('a')
@@ -157,7 +160,7 @@ interface Site {
           <table className="w-full text-sm">
             <thead className="bg-gray-50">
               <tr>
-                {['Site name', 'Heritage type', 'Source', 'Slope', 'Fuel age', 'Granite', 'Vulnerability', 'Assessed', ''].map((h) => (
+                {['Site name', 'Heritage type', 'Source', 'Slope', 'Fuel Type', 'Granite Influence', 'Vulnerability', 'Assessed', ''].map((h) => (
                   <th key={h} className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wider text-gray-400">
                     {h}
                   </th>
@@ -181,7 +184,7 @@ interface Site {
                     <td className="px-4 py-3 text-gray-600">{site.heritageType}</td>
                     <td className="px-4 py-3">{sourceBadge(site.source)}</td>
                     <td className="px-4 py-3 text-gray-600">{site.slope}°</td>
-                    <td className="px-4 py-3 text-gray-600">{site.fuelAge} yr</td>
+                    <td className="px-4 py-3 text-gray-600">{site.fuelType}</td>
                     <td className="px-4 py-3 text-gray-600">{site.granite}%</td>
                     <td className="px-4 py-3">{vulnerabilityPill(site.vulnerability)}</td>
                     <td className="px-4 py-3 text-gray-400">{site.assessedDate}</td>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -32,7 +32,7 @@ const Login = () => {
           {/* Feature bullets */}
           <div className="flex flex-col gap-3 mt-10">
             {[
-              'Predictive fire vulnerability modelling',
+              'Heritage Fire Vulnerability Model',
               'Heritage site registry — ACHIS & Inherit',
               'Franklin District (FRK) · Western Australia',
             ].map((item) => (

--- a/src/pages/ModelInsights.tsx
+++ b/src/pages/ModelInsights.tsx
@@ -57,7 +57,7 @@ import {
   }
   
   const radarData = {
-    labels: ['Slope', 'Fuel Age', 'Vegetation Density', 'Granite', 'Recent Burn'],
+    labels: ['Slope', 'Heritage Type', 'Vegetation Type', 'Granite Influence', 'Recent Burn'],
     datasets: [
       {
         data: [8, 7, 6, 5, 7],
@@ -91,13 +91,13 @@ import {
   const scatterData = {
     datasets: [
       {
-        label: 'Granite',
+        label: 'Granite Influence',
         data: generatePoints(8),
         backgroundColor: '#CD853F',
         pointRadius: 6,
       },
       {
-        label: 'Fuel Age',
+        label: 'Heritage Type',
         data: generatePoints(8),
         backgroundColor: '#2E8B57',
         pointRadius: 6,
@@ -109,7 +109,7 @@ import {
         pointRadius: 6,
       },
       {
-        label: 'Vegetation Density',
+        label: 'Vegetation Type',
         data: generatePoints(8),
         backgroundColor: '#6ABF69',
         pointRadius: 6,
@@ -139,7 +139,7 @@ import {
       <div className="flex flex-col px-8 py-8 overflow-y-auto h-full gap-4" style={{ background: '#F0EDE8' }}>
   
         {/* Title */}
-        <h1 className="text-3xl font-black text-center mb-2">Predictive Model Insights</h1>
+        <h1 className="text-3xl font-black text-center mb-2">Heritage Fire Vulnerability Model Insights</h1>
   
         {/* Bar Chart */}
         <div className="bg-white rounded-xl p-6">
@@ -167,10 +167,10 @@ import {
             {/* Legend */}
             <div className="flex flex-wrap gap-4 mt-3">
               {[
-                { label: 'Granite', color: '#CD853F' },
-                { label: 'Fuel Age', color: '#2E8B57' },
+                { label: 'Granite Influence', color: '#CD853F' },
+                { label: 'Heritage Type', color: '#2E8B57' },
                 { label: 'Slope', color: '#DAA520' },
-                { label: 'Vegetation Density', color: '#6ABF69' },
+                { label: 'Vegetation Type', color: '#6ABF69' },
               ].map((item) => (
                 <div key={item.label} className="flex items-center gap-2">
                   <div className="w-3 h-3 rounded-full" style={{ backgroundColor: item.color }} />

--- a/src/pages/RiskMap.tsx
+++ b/src/pages/RiskMap.tsx
@@ -1,8 +1,13 @@
 import { useState } from 'react'
 
+// NBIC Bushfire Fuel Classification — see "Fuel type attribute table" data source.
+// TODO(PO): confirm final class list and risk weighting (see issue #15).
+const FUEL_TYPES = ['Forest', 'Woodland', 'Shrubland', 'Heath', 'Mallee', 'Grassland'] as const
+type FuelType = typeof FUEL_TYPES[number]
+
 const RiskMap = () => {
   const [slope, setSlope] = useState(15)
-  const [fuelAge, setFuelAge] = useState(12)
+  const [fuelType, setFuelType] = useState<FuelType>('Woodland')
   const [graniteIndex, setGraniteIndex] = useState(40)
 
   return (
@@ -13,7 +18,7 @@ const RiskMap = () => {
         {/* Avatar + Title */}
         <div className="flex items-center justify-between mb-6">
           <h1 className="text-2xl font-black uppercase leading-tight tracking-tight">
-            Fire Risk<br />Predictive<br />Model
+            Heritage Fire<br />Vulnerability<br />Model
           </h1>
           <div className="w-10 h-10 rounded-full bg-gray-800 flex items-center justify-center flex-shrink-0">
             <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
@@ -53,21 +58,21 @@ const RiskMap = () => {
 
           {/* Vegetation */}
           <div>
-            <p className="font-bold text-base mb-3">Vegetation (Fuel Age)</p>
-            <input
-              type="range"
-              min={0}
-              max={30}
-              value={fuelAge}
-              onChange={(e) => setFuelAge(Number(e.target.value))}
-              className="w-full accent-[#8B2020] h-1 cursor-pointer"
-            />
-            <p className="text-right text-sm text-gray-500 mt-1">{fuelAge} yrs</p>
+            <p className="font-bold text-base mb-3">Vegetation (Fuel Type)</p>
+            <select
+              value={fuelType}
+              onChange={(e) => setFuelType(e.target.value as FuelType)}
+              className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-700 bg-gray-50 outline-none focus:border-gray-400 focus:bg-white transition-colors cursor-pointer"
+            >
+              {FUEL_TYPES.map((t) => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
           </div>
 
           {/* Granite */}
           <div>
-            <p className="font-bold text-base mb-3">Granite (Outcrop Index)</p>
+            <p className="font-bold text-base mb-3">Granite Influence</p>
             <input
               type="range"
               min={0}

--- a/src/pages/SiteAssessment.tsx
+++ b/src/pages/SiteAssessment.tsx
@@ -78,13 +78,15 @@ const SiteAssessment = () => {
   const [slope, setSlope] = useState(28)
   const [fuelType, setFuelType] = useState<FuelType>('Forest')
   const [granite, setGranite] = useState(65)
-  const [wind, setWind] = useState(4)
 
   const slopeScore = Math.round((slope / 45) * 100)
   const fuelScore = FUEL_TYPE_SCORE[fuelType]
   const graniteScore = granite
-  const windScore = Math.round((wind / 5) * 100)
-  const totalScore = Math.round(slopeScore * 0.3 + fuelScore * 0.25 + graniteScore * 0.25 + windScore * 0.2)
+  // TODO(PO): final factor weights pending full vulnerability spec.
+  // Provisional values preserve the existing slope:fuel:granite ratio (6:5:5)
+  // after removing Wind (issue #15 / Q3 follow-up). Slope spec mandates 0.35;
+  // fuel/granite split of remaining 0.65 still needs PO confirmation.
+  const totalScore = Math.round(slopeScore * 0.375 + fuelScore * 0.3125 + graniteScore * 0.3125)
 
   const vulnerability = getVulnerability(totalScore)
   const circleStyle = getCircleStyle(vulnerability)
@@ -100,7 +102,6 @@ const SiteAssessment = () => {
       ['Slope', `${slope}°`],
       ['Fuel Type', fuelType],
       ['Granite Influence', `${granite}%`],
-      ['Wind Exposure', `${wind}/5`],
       ['Vulnerability Score', totalScore],
       ['Vulnerability Level', vulnerability],
     ]
@@ -226,18 +227,6 @@ const SiteAssessment = () => {
                 <div className="flex justify-between text-xs text-gray-300 mt-1"><span>0%</span><span>100%</span></div>
               </div>
 
-              {/* Wind */}
-              <div>
-                <div className="flex justify-between items-center mb-2">
-                  <span className="text-sm font-bold text-gray-700">Wind Exposure</span>
-                  <span className="text-xs font-extrabold text-[#8B2020] bg-red-50 px-2 py-0.5 rounded-md">{wind} / 5</span>
-                </div>
-                <input type="range" min={1} max={5} value={wind} step={1}
-                  onChange={(e) => setWind(Number(e.target.value))}
-                  className="w-full accent-[#8B2020] h-1 cursor-pointer" />
-                <div className="flex justify-between text-xs text-gray-300 mt-1"><span>Sheltered</span><span>Exposed</span></div>
-              </div>
-
             </div>
           </div>
         </div>
@@ -270,7 +259,6 @@ const SiteAssessment = () => {
                 { label: 'Slope', val: slopeScore },
                 { label: 'Fuel Type', val: fuelScore },
                 { label: 'Granite Influence', val: graniteScore },
-                { label: 'Wind', val: windScore },
               ].map((f) => (
                 <div key={f.label} className="flex items-center gap-3">
                   <span className="text-xs text-gray-500 w-28 flex-shrink-0">{f.label}</span>

--- a/src/pages/SiteAssessment.tsx
+++ b/src/pages/SiteAssessment.tsx
@@ -12,6 +12,19 @@ type HeritageType =
 type Source = 'ACHIS' | 'Inherit' | 'Field observation'
 type Vulnerability = 'High' | 'Medium' | 'Low'
 
+// NBIC Bushfire Fuel Classification — see "Fuel type attribute table" data source.
+// TODO(PO): confirm final class list and per-class risk weighting (issue #15).
+const FUEL_TYPES = ['Forest', 'Woodland', 'Shrubland', 'Heath', 'Mallee', 'Grassland'] as const
+type FuelType = typeof FUEL_TYPES[number]
+const FUEL_TYPE_SCORE: Record<FuelType, number> = {
+  Forest: 90,
+  Shrubland: 80,
+  Heath: 75,
+  Woodland: 70,
+  Mallee: 65,
+  Grassland: 50,
+}
+
 interface Action {
   text: string
   priority: 'Urgent' | 'High priority' | 'Standard'
@@ -63,12 +76,12 @@ const SiteAssessment = () => {
   const [heritageType, setHeritageType] = useState<HeritageType>('Rock art / petroglyphs')
   const [source, setSource] = useState<Source>('ACHIS')
   const [slope, setSlope] = useState(28)
-  const [fuelAge, setFuelAge] = useState(14)
+  const [fuelType, setFuelType] = useState<FuelType>('Forest')
   const [granite, setGranite] = useState(65)
   const [wind, setWind] = useState(4)
 
   const slopeScore = Math.round((slope / 45) * 100)
-  const fuelScore = Math.round((fuelAge / 30) * 100)
+  const fuelScore = FUEL_TYPE_SCORE[fuelType]
   const graniteScore = granite
   const windScore = Math.round((wind / 5) * 100)
   const totalScore = Math.round(slopeScore * 0.3 + fuelScore * 0.25 + graniteScore * 0.25 + windScore * 0.2)
@@ -85,8 +98,8 @@ const SiteAssessment = () => {
       ['Heritage Type', heritageType],
       ['Source', source],
       ['Slope', `${slope}°`],
-      ['Fuel Age', `${fuelAge} yrs`],
-      ['Granite Index', `${granite}%`],
+      ['Fuel Type', fuelType],
+      ['Granite Influence', `${granite}%`],
       ['Wind Exposure', `${wind}/5`],
       ['Vulnerability Score', totalScore],
       ['Vulnerability Level', vulnerability],
@@ -184,22 +197,27 @@ const SiteAssessment = () => {
                 <div className="flex justify-between text-xs text-gray-300 mt-1"><span>0°</span><span>45°</span></div>
               </div>
 
-              {/* Fuel Age */}
+              {/* Fuel Type */}
               <div>
                 <div className="flex justify-between items-center mb-2">
-                  <span className="text-sm font-bold text-gray-700">Vegetation (Fuel Age)</span>
-                  <span className="text-xs font-extrabold text-[#8B2020] bg-red-50 px-2 py-0.5 rounded-md">{fuelAge} yrs</span>
+                  <span className="text-sm font-bold text-gray-700">Vegetation (Fuel Type)</span>
+                  <span className="text-xs font-extrabold text-[#8B2020] bg-red-50 px-2 py-0.5 rounded-md">{fuelType}</span>
                 </div>
-                <input type="range" min={0} max={30} value={fuelAge} step={1}
-                  onChange={(e) => setFuelAge(Number(e.target.value))}
-                  className="w-full accent-[#8B2020] h-1 cursor-pointer" />
-                <div className="flex justify-between text-xs text-gray-300 mt-1"><span>0 yrs</span><span>30 yrs</span></div>
+                <select
+                  value={fuelType}
+                  onChange={(e) => setFuelType(e.target.value as FuelType)}
+                  className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-700 bg-gray-50 outline-none focus:border-gray-400 focus:bg-white transition-colors cursor-pointer"
+                >
+                  {FUEL_TYPES.map((t) => (
+                    <option key={t} value={t}>{t}</option>
+                  ))}
+                </select>
               </div>
 
               {/* Granite */}
               <div>
                 <div className="flex justify-between items-center mb-2">
-                  <span className="text-sm font-bold text-gray-700">Granite (Outcrop Index)</span>
+                  <span className="text-sm font-bold text-gray-700">Granite Influence</span>
                   <span className="text-xs font-extrabold text-[#8B2020] bg-red-50 px-2 py-0.5 rounded-md">{granite}%</span>
                 </div>
                 <input type="range" min={0} max={100} value={granite} step={1}
@@ -250,12 +268,12 @@ const SiteAssessment = () => {
             <div className="flex flex-col gap-2.5">
               {[
                 { label: 'Slope', val: slopeScore },
-                { label: 'Fuel age', val: fuelScore },
-                { label: 'Granite', val: graniteScore },
+                { label: 'Fuel Type', val: fuelScore },
+                { label: 'Granite Influence', val: graniteScore },
                 { label: 'Wind', val: windScore },
               ].map((f) => (
                 <div key={f.label} className="flex items-center gap-3">
-                  <span className="text-xs text-gray-500 w-20 flex-shrink-0">{f.label}</span>
+                  <span className="text-xs text-gray-500 w-28 flex-shrink-0">{f.label}</span>
                   <div className="flex-1 h-1.5 bg-gray-800 rounded-full overflow-hidden">
                     <div className="h-full rounded-full transition-all duration-500"
                       style={{ width: `${f.val}%`, background: getFactorColor(f.val) }} />


### PR DESCRIPTION
## Summary

Standardises user-facing terminology across the app per teacher/client feedback,
and removes the Wind Exposure factor from the vulnerability model UI per PO
confirmation.

Closes #15
Closes #24

---

## Terminology changes (issue #15)

| Old term | New term | Status |
|---|---|---|
| Fuel Age | Fuel Type | ✅ Done — slider replaced with NBIC fuel-class select |
| Fire Risk Predictive Model | Heritage Fire Vulnerability Model | ✅ Done |
| Granite (Outcrop Index) / Granite Index / Granite | Granite Influence | ✅ Done |
| MVP (as product name) | dropped | ✅ Done — Sidebar footer "v1.0 MVP" → "v1.0 Pilot" |
| Burn Options | DBCA Proposed Prescribed Burn Areas | ⚠️ Not in current frontend code (no map layer renders this yet). Naming convention noted for the future map-layer PR. |

## Wind removal (issue #24)

PO confirmed Wind Exposure is not part of the heritage fire vulnerability model.
Removed the slider, state, score calc, CSV row, and Contributing factors entry
from `SiteAssessment.tsx`. `totalScore` weights re-balanced to sum to 1.0,
preserving the previous slope:fuel:granite ratio (6:5:5 → 0.375 / 0.3125 / 0.3125).

> ⚠️ These are **provisional** weights. The slope spec mandates `0.35`, but the
> remaining 0.65 split between fuel/granite (and any future factors) is still
> pending PO. A `TODO(PO)` comment is left at the formula site, and the full
> model alignment will be tracked in a follow-up issue.

---

## Changes by file

- **`src/components/layout/Sidebar.tsx`**
  Sidebar footer `v1.0 MVP` → `v1.0 Pilot`.
- **`src/pages/Login.tsx`**
  Feature bullet `"Predictive fire vulnerability modelling"` → `"Heritage Fire Vulnerability Model"`.
- **`src/pages/RiskMap.tsx`**
  Header `"Fire Risk / Predictive / Model"` → `"Heritage Fire / Vulnerability / Model"`.
  Vegetation slider replaced with **Fuel Type** `<select>` over NBIC classes
  (`Forest / Woodland / Shrubland / Heath / Mallee / Grassland`); `yrs` unit removed.
  Granite control renamed `"Granite (Outcrop Index)"` → `"Granite Influence"`.
- **`src/pages/SiteAssessment.tsx`**
  Same Fuel Type select + Granite Influence rename.
  `fuelScore` switched from continuous formula to a `FUEL_TYPE_SCORE` lookup table.
  Wind block, state, score, CSV row, and Contributing factors entry removed.
  `totalScore` weights re-balanced (see "Wind removal" section above).
  Contributing factors label column widened (`w-20` → `w-28`) to fit `"Granite Influence"`.
  Bug fix in `exportCSV`: the duplicate `'Heritage Type'` row (which was actually
  showing fuel age) is now `'Fuel Type'`. `'Granite Index'` → `'Granite Influence'`.
- **`src/pages/HeritagRegistry.tsx`**
  `Site.fuelAge: number` → `Site.fuelType: FuelType`. Mock data converted from
  numeric ages to fuel-class names (preserving the original High/Medium/Low
  distribution). Table header `"Fuel age"` / `"Granite"` → `"Fuel Type"` / `"Granite Influence"`.
  CSV header same. Cell renders `{site.fuelType}` (no `yr` suffix).
- **`src/pages/ModelInsights.tsx`**
  Page title `"Predictive Model Insights"` → `"Heritage Fire Vulnerability Model Insights"`.
  Radar chart label, scatter dataset label, and legend `"Granite"` → `"Granite Influence"`.

---

## Out of scope / follow-ups

- **`project_plan.v1.md`** still contains two historical references to "MVP"
  (`D1 Draft & MVP Agreement`, `MVP Scope & UI Design`). These are **past
  milestone names** describing completed weeks of work, not product naming.
  Kept as-is — please flag in review if you want them rewritten.
- **Presentation deck / external docs** are not in this repo. Please verify
  out-of-band that they use the new terms before the next demo.
- **Slope risk formula** (5/15/25 thresholds, 0–100 with linear interpolation)
  is *not* updated yet — current frontend still uses the old `(slope/45)*100`
  shortcut. This will be addressed in the upcoming Heritage Fire Vulnerability
  Model implementation issue (TBD), once PO has confirmed the full factor spec.
- **Fuel / Granite / Heritage / Burn factor weights** are placeholder values
  (see `TODO(PO)` comment). Awaiting full vulnerability model spec from PO.

---

## Testing

- `npx tsc -b --noEmit` — no new errors introduced. (Two pre-existing errors
  remain: unused `RouterProvider` import in `src/main.tsx`, and `vite.config.ts`
  `test` field — both unrelated to this PR.)
- `grep` confirms `Fuel Age` / `Fire Risk Predictive` / `Granite Geology` /
  `Granite (Outcrop` / `Granite Index` / `Predictive Model Insights` are gone
  from `src/`.
- `grep` confirms `wind|Wind` is gone from `src/pages/` (only remaining match
  is the `TODO` comment that explains *why* Wind was removed).
- Manual check pending: open each page in dev mode and verify no truncated
  labels, no broken layouts.

---

## Reviewer checklist

- [ ] All five term mappings reflected in UI (Fuel Type select, Heritage Fire
      Vulnerability Model header, Granite Influence labels, no MVP in Sidebar)
- [ ] No Wind slider, no Wind row in CSV, no Wind in Contributing factors
- [ ] `totalScore` denominators look right (no scores stuck below 80)
- [ ] OK with provisional weights + `TODO(PO)` plan to revisit
- [ ] OK with leaving Burn Options for the future map-layer PR
- [ ] OK with leaving historical `MVP` references in `project_plan.v1.md`