### PR TITLE
Enhancement&Test：Integrate FireWatch Heritage map into Risk Map page & Frontend-test

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,11 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
-import { RouterProvider } from 'react-router-dom'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    
     <App />
   </StrictMode>,
 )

--- a/src/pages/RiskMap.css
+++ b/src/pages/RiskMap.css
@@ -1,0 +1,388 @@
+.firewatch-risk-page {
+  display: grid;
+  grid-template-columns: minmax(320px, 390px) 1fr;
+  min-height: 100%;
+  background: #d8e9ed;
+}
+
+.firewatch-risk-page *,
+.firewatch-risk-page *::before,
+.firewatch-risk-page *::after {
+  box-sizing: border-box;
+}
+
+.firewatch-risk-page__panel {
+  position: relative;
+  z-index: 800;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  max-height: 100vh;
+  overflow: auto;
+  padding: 24px;
+  background: #f7f7f4;
+  border-right: 1px solid #d8d9d2;
+}
+
+.firewatch-brand__eyebrow {
+  margin: 0 0 8px;
+  color: #297a8c;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.firewatch-brand__title,
+.firewatch-risk-page h2,
+.firewatch-risk-page h3,
+.firewatch-risk-page p {
+  margin-top: 0;
+}
+
+.firewatch-brand__title {
+  margin-bottom: 10px;
+  font-size: 30px;
+  line-height: 1.05;
+  color: #202124;
+}
+
+.firewatch-brand__lede,
+.firewatch-details__intro,
+.firewatch-method__note {
+  color: #62676c;
+  line-height: 1.45;
+}
+
+.firewatch-summary {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.firewatch-summary__card,
+.firewatch-card {
+  border: 1px solid #d8d9d2;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.firewatch-summary__card {
+  padding: 12px;
+}
+
+.firewatch-summary__card span {
+  display: block;
+  font-size: 28px;
+  font-weight: 800;
+  color: #202124;
+}
+
+.firewatch-summary__card small {
+  color: #62676c;
+  font-weight: 700;
+}
+
+.firewatch-card {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+}
+
+.firewatch-risk-page h2 {
+  margin-bottom: 0;
+  font-size: 16px;
+  color: #202124;
+}
+
+.firewatch-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #202124;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.firewatch-key-group {
+  display: grid;
+  gap: 6px;
+  padding-top: 10px;
+  border-top: 1px solid #ecece7;
+}
+
+.firewatch-key-group:first-of-type {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.firewatch-key-group h3 {
+  margin: 0;
+  color: #202124;
+  font-size: 13px;
+}
+
+.firewatch-key-group div {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #62676c;
+  font-size: 12px;
+  line-height: 1.3;
+}
+
+.firewatch-key-box,
+.firewatch-key-line,
+.firewatch-key-dot {
+  flex: 0 0 auto;
+}
+
+.firewatch-key-box {
+  width: 18px;
+  height: 12px;
+  border-radius: 4px;
+}
+
+.firewatch-key-line {
+  width: 20px;
+  height: 4px;
+  border-radius: 4px;
+}
+
+.firewatch-key-dot {
+  width: 12px;
+  height: 12px;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.25);
+}
+
+.firewatch-key-box--high,
+.firewatch-key-dot--heritage {
+  background: #d2302a;
+}
+
+.firewatch-key-box--medium {
+  background: #ebae26;
+}
+
+.firewatch-key-box--low {
+  background: #14964b;
+}
+
+.firewatch-key-box--forest {
+  background: #2f7f69;
+}
+
+.firewatch-key-box--shrub {
+  background: #b45f4c;
+}
+
+.firewatch-key-box--grass {
+  background: #bfaa36;
+}
+
+.firewatch-key-box--wet {
+  background: #55a6a2;
+}
+
+.firewatch-key-box--urban {
+  background: #87919a;
+}
+
+.firewatch-key-box--slope-low {
+  background: #58a66d;
+}
+
+.firewatch-key-box--slope-mid {
+  background: #c8b936;
+}
+
+.firewatch-key-box--slope-high {
+  background: #d78d26;
+}
+
+.firewatch-key-box--slope-vhigh {
+  background: #b62f2a;
+}
+
+.firewatch-key-line--burn {
+  background: #167d94;
+}
+
+.firewatch-key-box--granite {
+  background: #6e684b;
+  border: 1px solid #2f3033;
+}
+
+.firewatch-controls {
+  display: grid;
+  gap: 12px;
+}
+
+.firewatch-filter-set {
+  display: grid;
+  gap: 8px;
+}
+
+.firewatch-filter-set p {
+  margin-bottom: 0;
+  color: #202124;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.firewatch-button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.firewatch-filter-button {
+  border: 1px solid #d8d9d2;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #62676c;
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.firewatch-filter-button:hover {
+  border-color: #297a8c;
+  color: #202124;
+}
+
+.firewatch-filter-button.is-active {
+  border-color: #297a8c;
+  background: #e7f2f4;
+  color: #202124;
+}
+
+.firewatch-details {
+  gap: 10px;
+}
+
+.firewatch-metric-list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+}
+
+.firewatch-metric {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 4px;
+}
+
+.firewatch-metric dt {
+  color: #62676c;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.firewatch-metric dd {
+  margin: 0;
+  color: #202124;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.firewatch-method p {
+  margin-bottom: 0;
+  color: #202124;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.firewatch-method__note {
+  font-size: 12px;
+}
+
+.firewatch-map-wrap {
+  position: relative;
+  min-height: 100vh;
+  background: #eef0e5;
+}
+
+#firewatch-risk-map {
+  width: 100%;
+  height: 100%;
+  min-height: 100vh;
+}
+
+.firewatch-map-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(247, 247, 244, 0.72);
+  color: #202124;
+  font-size: 14px;
+  font-weight: 700;
+  pointer-events: none;
+}
+
+.firewatch-map-overlay--error {
+  color: #8b2020;
+}
+
+.firewatch-map-wrap .leaflet-control-zoom {
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.firewatch-map-wrap .leaflet-control-zoom a {
+  width: 28px;
+  height: 28px;
+  color: #202124;
+  line-height: 28px;
+  text-align: center;
+  text-decoration: none;
+  font-weight: 800;
+}
+
+.firewatch-map-wrap .leaflet-control-attribution {
+  padding: 2px 6px;
+  background: rgba(255, 255, 255, 0.82);
+  font-size: 11px;
+}
+
+.firewatch-map-wrap .leaflet-control-attribution a {
+  color: #297a8c;
+}
+
+.firewatch-study-label__bubble {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid #202124;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.96);
+  color: #202124;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+@media (max-width: 1100px) {
+  .firewatch-risk-page {
+    grid-template-columns: 1fr;
+  }
+
+  .firewatch-risk-page__panel {
+    max-height: none;
+    border-right: 0;
+    border-bottom: 1px solid #d8d9d2;
+  }
+
+  .firewatch-map-wrap,
+  #firewatch-risk-map {
+    min-height: 70vh;
+  }
+}

--- a/src/pages/RiskMap.tsx
+++ b/src/pages/RiskMap.tsx
@@ -1,110 +1,796 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import './RiskMap.css'
 
-// NBIC Bushfire Fuel Classification — see "Fuel type attribute table" data source.
-// TODO(PO): confirm final class list and risk weighting (see issue #15).
-const FUEL_TYPES = ['Forest', 'Woodland', 'Shrubland', 'Heath', 'Mallee', 'Grassland'] as const
-type FuelType = typeof FUEL_TYPES[number]
+type RiskLevel = 'High' | 'Medium' | 'Low'
+type HeritageKindFilter = 'all' | 'Aboriginal' | 'Non-Aboriginal'
+type HeritageRiskFilter = 'all' | RiskLevel
+type LayerName = 'fire' | 'heritage' | 'burn' | 'granite' | 'fuel' | 'slope'
 
-const RiskMap = () => {
-  const [slope, setSlope] = useState(15)
-  const [fuelType, setFuelType] = useState<FuelType>('Woodland')
-  const [graniteIndex, setGraniteIndex] = useState(40)
+type Metric = {
+  label: string
+  value: string
+}
+
+type DetailState = {
+  title: string
+  intro: string
+  metrics: Metric[]
+}
+
+type ToggleState = Record<LayerName, boolean>
+
+type FeatureCollection = {
+  type: 'FeatureCollection'
+  features: GeoFeature[]
+}
+
+type GeoFeature = {
+  type: string
+  geometry: {
+    type: string
+    coordinates: unknown
+  } | null
+  properties: Record<string, unknown>
+}
+
+type Metadata = {
+  analysis_bounds_epsg_7844: [number, number, number, number]
+  counts: {
+    heritage_levels: Record<RiskLevel, number>
+  }
+  raster_overlays: {
+    bounds_epsg_7844: [number, number, number, number]
+    classification: {
+      low: string
+      medium: string
+      high: string
+    }
+    files: {
+      fire: string
+      fuel: string
+      slope: string
+    }
+  }
+}
+
+type HeritageProperties = {
+  layer: 'Heritage'
+  identifier?: string
+  name?: string
+  heritage_kind?: 'Aboriginal' | 'Non-Aboriginal'
+  place_status?: string
+  place_type?: string
+  region?: string
+  culturally_sensitive?: string
+  fuel_class?: string
+  slope_degrees?: number | null
+  slope_data_quality?: string
+  heritage_type_risk_label?: string
+  heritage_type_risk?: number
+  burn_management_context?: string
+  vulnerability_score?: number
+  vulnerability_level?: RiskLevel
+  latitude?: number
+  longitude?: number
+}
+
+type GraniteProperties = {
+  layer: 'Granite influence'
+  unit_name?: string
+  code?: string
+  description?: string
+  rock_type?: string
+  lithology?: string
+}
+
+type BurnProperties = {
+  layer: 'Burn option'
+  burnid?: string
+  location?: string
+  status?: string
+  priority?: number
+  fin_yr?: string
+  purpose?: string
+}
+
+declare global {
+  interface Window {
+    L?: any
+  }
+}
+
+const DATA_BASE = `${import.meta.env.BASE_URL}data/processed/`
+const IS_TEST_ENV = import.meta.env.MODE === 'test'
+
+const defaultLayerVisibility: ToggleState = {
+  fire: true,
+  heritage: true,
+  burn: false,
+  granite: false,
+  fuel: false,
+  slope: false,
+}
+
+const defaultDetails: DetailState = {
+  title: 'Select a heritage place',
+  intro:
+    'Drag to pan, scroll to zoom, and click a heritage place, burn option, or geology area to inspect source attributes.',
+  metrics: [],
+}
+
+const levelColors: Record<RiskLevel, string> = {
+  High: '#d2302a',
+  Medium: '#ebae26',
+  Low: '#14964b',
+}
+
+function riskColor(level?: string) {
+  return levelColors[level as RiskLevel] ?? '#667078'
+}
+
+function formatValue(value: unknown, fallback = 'Unknown') {
+  if (value === null || value === undefined || value === '') return fallback
+  return String(value)
+}
+
+function loadExternalStylesheet(id: string, href: string) {
+  if (document.getElementById(id)) return
+
+  const link = document.createElement('link')
+  link.id = id
+  link.rel = 'stylesheet'
+  link.href = href
+  document.head.appendChild(link)
+}
+
+function loadExternalScript(id: string, src: string) {
+  return new Promise<void>((resolve, reject) => {
+    if (window.L) {
+      resolve()
+      return
+    }
+
+    const existingScript = document.getElementById(id) as HTMLScriptElement | null
+    if (existingScript) {
+      existingScript.addEventListener('load', () => resolve(), { once: true })
+      existingScript.addEventListener('error', () => reject(new Error('Could not load Leaflet.')), { once: true })
+      return
+    }
+
+    const script = document.createElement('script')
+    script.id = id
+    script.src = src
+    script.async = true
+    script.onload = () => resolve()
+    script.onerror = () => reject(new Error('Could not load Leaflet.'))
+    document.body.appendChild(script)
+  })
+}
+
+function getImageBounds(metadata: Metadata) {
+  const [west, south, east, north] = metadata.raster_overlays.bounds_epsg_7844
+  return [
+    [south, west],
+    [north, east],
+  ]
+}
+
+function getAnalysisBounds(metadata: Metadata) {
+  const [west, south, east, north] = metadata.analysis_bounds_epsg_7844
+  return [
+    [south, west],
+    [north, east],
+  ]
+}
+
+function getHeritageMarkerPosition(feature: GeoFeature, properties: HeritageProperties) {
+  if (typeof properties.latitude === 'number' && typeof properties.longitude === 'number') {
+    return [properties.latitude, properties.longitude] as [number, number]
+  }
+
+  if (feature.geometry?.type === 'Point' && Array.isArray(feature.geometry.coordinates)) {
+    const [longitude, latitude] = feature.geometry.coordinates as [number, number]
+    return [latitude, longitude] as [number, number]
+  }
+
+  return null
+}
+
+function RiskMap() {
+  const mapElementRef = useRef<HTMLDivElement | null>(null)
+  const mapRef = useRef<any>(null)
+  const studyAreaLayerRef = useRef<any>(null)
+  const studyAreaLabelRef = useRef<any>(null)
+  const layerRefs = useRef<Partial<Record<LayerName, any>>>({})
+
+  const [leafletReady, setLeafletReady] = useState(Boolean(window.L) || IS_TEST_ENV)
+  const [mapError, setMapError] = useState<string | null>(null)
+  const [metadata, setMetadata] = useState<Metadata | null>(null)
+  const [heritageData, setHeritageData] = useState<FeatureCollection | null>(null)
+  const [burnData, setBurnData] = useState<FeatureCollection | null>(null)
+  const [graniteData, setGraniteData] = useState<FeatureCollection | null>(null)
+  const [summary, setSummary] = useState<Record<RiskLevel, number>>({
+    High: 0,
+    Medium: 0,
+    Low: 0,
+  })
+  const [details, setDetails] = useState<DetailState>(defaultDetails)
+  const [visibleLayers, setVisibleLayers] = useState<ToggleState>(defaultLayerVisibility)
+  const [heritageRiskFilter, setHeritageRiskFilter] = useState<HeritageRiskFilter>('all')
+  const [heritageKindFilter, setHeritageKindFilter] = useState<HeritageKindFilter>('all')
+
+  const classification = metadata?.raster_overlays.classification
+
+  const summaryCards = useMemo(
+    () => [
+      { label: 'High', value: summary.High },
+      { label: 'Medium', value: summary.Medium },
+      { label: 'Low', value: summary.Low },
+    ],
+    [summary]
+  )
+
+  useEffect(() => {
+    if (IS_TEST_ENV) return
+
+    let active = true
+    loadExternalStylesheet('leaflet-cdn-css', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css')
+
+    loadExternalScript('leaflet-cdn-js', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js')
+      .then(() => {
+        if (active) setLeafletReady(true)
+      })
+      .catch((error) => {
+        if (active) setMapError(error.message)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [])
+
+  useEffect(() => {
+    if (IS_TEST_ENV) return
+
+    let active = true
+
+    async function loadData() {
+      try {
+        const [metadataResponse, heritageResponse, burnResponse, graniteResponse] = await Promise.all([
+          fetch(`${DATA_BASE}metadata.json`),
+          fetch(`${DATA_BASE}heritage_all_layer.geojson`),
+          fetch(`${DATA_BASE}burn_options_layer.geojson`),
+          fetch(`${DATA_BASE}granite_layer.geojson`),
+        ])
+
+        if (!metadataResponse.ok || !heritageResponse.ok || !burnResponse.ok || !graniteResponse.ok) {
+          throw new Error('Could not load processed Risk Map data.')
+        }
+
+        const [metadataJson, heritageJson, burnJson, graniteJson] = await Promise.all([
+          metadataResponse.json(),
+          heritageResponse.json(),
+          burnResponse.json(),
+          graniteResponse.json(),
+        ])
+
+        if (!active) return
+
+        setMetadata(metadataJson)
+        setHeritageData(heritageJson)
+        setBurnData(burnJson)
+        setGraniteData(graniteJson)
+      } catch (error) {
+        if (active) {
+          setMapError(error instanceof Error ? error.message : 'Could not load processed Risk Map data.')
+        }
+      }
+    }
+
+    loadData()
+
+    return () => {
+      active = false
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!leafletReady || !mapElementRef.current || mapRef.current || !window.L || IS_TEST_ENV) return
+
+    const L = window.L
+    const map = L.map(mapElementRef.current, {
+      preferCanvas: true,
+      zoomControl: true,
+      dragging: true,
+      scrollWheelZoom: true,
+      doubleClickZoom: true,
+      boxZoom: true,
+      keyboard: true,
+      minZoom: 8,
+      maxZoom: 19,
+    }).setView([-34.7, 117.45], 9)
+
+    map.createPane('rasterPane')
+    map.getPane('rasterPane').style.zIndex = '350'
+    map.getPane('rasterPane').style.pointerEvents = 'none'
+
+    map.createPane('contextPane')
+    map.getPane('contextPane').style.zIndex = '430'
+
+    map.createPane('heritagePane')
+    map.getPane('heritagePane').style.zIndex = '520'
+
+    map.createPane('heritageMarkerPane')
+    map.getPane('heritageMarkerPane').style.zIndex = '650'
+
+    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19,
+      crossOrigin: true,
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+    }).addTo(map)
+
+    mapRef.current = map
+
+    return () => {
+      map.remove()
+      mapRef.current = null
+    }
+  }, [leafletReady])
+
+  useEffect(() => {
+    if (
+      IS_TEST_ENV ||
+      !leafletReady ||
+      !window.L ||
+      !mapRef.current ||
+      !metadata ||
+      !heritageData ||
+      !burnData ||
+      !graniteData
+    ) {
+      return
+    }
+
+    const L = window.L
+    const map = mapRef.current
+
+    Object.values(layerRefs.current).forEach((layer) => {
+      if (layer && map.hasLayer(layer)) {
+        map.removeLayer(layer)
+      }
+    })
+
+    if (studyAreaLayerRef.current && map.hasLayer(studyAreaLayerRef.current)) {
+      map.removeLayer(studyAreaLayerRef.current)
+    }
+
+    if (studyAreaLabelRef.current && map.hasLayer(studyAreaLabelRef.current)) {
+      map.removeLayer(studyAreaLabelRef.current)
+    }
+
+    const filteredHeritage = heritageData.features.filter((feature) => {
+      const properties = feature.properties as HeritageProperties
+      const kindOk = heritageKindFilter === 'all' || properties.heritage_kind === heritageKindFilter
+      const riskOk = heritageRiskFilter === 'all' || properties.vulnerability_level === heritageRiskFilter
+      return kindOk && riskOk
+    })
+
+    const counts = filteredHeritage.reduce(
+      (acc, feature) => {
+        const level = (feature.properties as HeritageProperties).vulnerability_level
+        if (level) acc[level] += 1
+        return acc
+      },
+      { High: 0, Medium: 0, Low: 0 } as Record<RiskLevel, number>
+    )
+    setSummary(counts)
+
+    const imageBounds = getImageBounds(metadata)
+    const fireOverlay = L.imageOverlay(`${DATA_BASE}${metadata.raster_overlays.files.fire}`, imageBounds, {
+      opacity: 0.92,
+      interactive: false,
+      pane: 'rasterPane',
+    })
+    const fuelOverlay = L.imageOverlay(`${DATA_BASE}${metadata.raster_overlays.files.fuel}`, imageBounds, {
+      opacity: 0.62,
+      interactive: false,
+      pane: 'rasterPane',
+    })
+    const slopeOverlay = L.imageOverlay(`${DATA_BASE}${metadata.raster_overlays.files.slope}`, imageBounds, {
+      opacity: 0.62,
+      interactive: false,
+      pane: 'rasterPane',
+    })
+
+    const setHeritageDetails = (properties: HeritageProperties) => {
+      setDetails({
+        title: properties.name || properties.identifier || 'Heritage place',
+        intro: `${formatValue(properties.heritage_kind)} heritage · ${formatValue(
+          properties.vulnerability_level
+        )} vulnerability, score ${formatValue(properties.vulnerability_score, 'Unknown')}/100.`,
+        metrics: [
+          { label: 'Identifier', value: formatValue(properties.identifier) },
+          { label: 'Name', value: formatValue(properties.name) },
+          { label: 'Heritage type', value: formatValue(properties.heritage_kind) },
+          { label: 'Status', value: formatValue(properties.place_status) },
+          { label: 'Place type', value: formatValue(properties.place_type) },
+          { label: 'Region / LGA', value: formatValue(properties.region) },
+          { label: 'Sensitive', value: formatValue(properties.culturally_sensitive) },
+          { label: 'Fuel', value: formatValue(properties.fuel_class) },
+          {
+            label: 'Slope',
+            value:
+              typeof properties.slope_degrees === 'number'
+                ? `${properties.slope_degrees.toFixed(2)} deg`
+                : 'Unknown',
+          },
+          { label: 'Slope data', value: formatValue(properties.slope_data_quality) },
+          { label: 'Heritage material/type', value: formatValue(properties.heritage_type_risk_label) },
+          { label: 'Material/type risk', value: formatValue(properties.heritage_type_risk) },
+          { label: 'Burn context', value: formatValue(properties.burn_management_context) },
+        ],
+      })
+    }
+
+    const setGraniteDetails = (properties: GraniteProperties) => {
+      setDetails({
+        title: properties.unit_name || 'Granite influence',
+        intro: properties.description || 'Granite / granitoid geology context.',
+        metrics: [
+          { label: 'Code', value: formatValue(properties.code) },
+          { label: 'Rock type', value: formatValue(properties.rock_type) },
+          { label: 'Lithology', value: formatValue(properties.lithology) },
+          { label: 'Influence value', value: '100 inside granite-related polygon' },
+        ],
+      })
+    }
+
+    const setBurnDetails = (properties: BurnProperties) => {
+      setDetails({
+        title: properties.location || 'Burn option area',
+        intro: properties.status || 'Burn option management context.',
+        metrics: [
+          { label: 'Burn ID', value: formatValue(properties.burnid) },
+          { label: 'Financial year', value: formatValue(properties.fin_yr) },
+          { label: 'Priority', value: formatValue(properties.priority) },
+          { label: 'Purpose', value: formatValue(properties.purpose) },
+        ],
+      })
+    }
+
+    const heritagePolygons = L.geoJSON(
+      { type: 'FeatureCollection', features: filteredHeritage },
+      {
+        style: (feature: GeoFeature) => {
+          const properties = feature.properties as HeritageProperties
+          return {
+            color: riskColor(properties.vulnerability_level),
+            weight: 2.4,
+            opacity: 1,
+            fillColor: riskColor(properties.vulnerability_level),
+            fillOpacity: 0.22,
+            pane: 'heritagePane',
+          }
+        },
+        onEachFeature: (feature: GeoFeature, layer: any) => {
+          const properties = feature.properties as HeritageProperties
+          layer.on('click', () => setHeritageDetails(properties))
+          layer.bindPopup(
+            `<strong>${formatValue(properties.name, 'Heritage place')}</strong><br>${formatValue(
+              properties.heritage_kind,
+              'Heritage'
+            )} heritage`
+          )
+        },
+        pane: 'heritagePane',
+      }
+    )
+
+    const heritageMarkers = L.layerGroup(
+      filteredHeritage
+        .map((feature) => {
+          const properties = feature.properties as HeritageProperties
+          const position = getHeritageMarkerPosition(feature, properties)
+          if (!position) return null
+
+          const marker = L.circleMarker(position, {
+            pane: 'heritageMarkerPane',
+            radius: properties.vulnerability_level === 'High' ? 9 : 7,
+            color: '#ffffff',
+            weight: 2,
+            fillColor: riskColor(properties.vulnerability_level),
+            fillOpacity: 0.98,
+          })
+
+          marker.on('click', () => setHeritageDetails(properties))
+          marker.bindPopup(
+            `<strong>${formatValue(properties.name, 'Heritage place')}</strong><br>${formatValue(
+              properties.heritage_kind,
+              'Heritage'
+            )} heritage`
+          )
+          return marker
+        })
+        .filter(Boolean)
+    )
+
+    const burnLayer = L.geoJSON(burnData, {
+      style: {
+        color: '#167d94',
+        weight: 3,
+        opacity: 1,
+        fillColor: '#47a6b6',
+        fillOpacity: 0.16,
+        dashArray: '9 5',
+        pane: 'contextPane',
+      },
+      onEachFeature: (feature: GeoFeature, layer: any) => {
+        const properties = feature.properties as BurnProperties
+        layer.on('click', () => setBurnDetails(properties))
+        layer.bindPopup(`<strong>${formatValue(properties.location, 'Burn option area')}</strong><br>Burn option`)
+      },
+      pane: 'contextPane',
+    })
+
+    const graniteLayer = L.geoJSON(graniteData, {
+      style: {
+        color: '#2f3033',
+        weight: 2.2,
+        opacity: 0.95,
+        fillColor: '#6e684b',
+        fillOpacity: 0.44,
+        pane: 'contextPane',
+      },
+      onEachFeature: (feature: GeoFeature, layer: any) => {
+        const properties = feature.properties as GraniteProperties
+        layer.on('click', () => setGraniteDetails(properties))
+        layer.bindPopup(`<strong>${formatValue(properties.unit_name, 'Granite influence')}</strong><br>Granite influence`)
+      },
+      pane: 'contextPane',
+    })
+
+    const heritageLayer = L.layerGroup([heritagePolygons, heritageMarkers])
+
+    layerRefs.current = {
+      fire: fireOverlay,
+      fuel: fuelOverlay,
+      slope: slopeOverlay,
+      burn: burnLayer,
+      granite: graniteLayer,
+      heritage: heritageLayer,
+    }
+
+    ;(Object.entries(defaultLayerVisibility) as Array<[LayerName, boolean]>).forEach(([layerName]) => {
+      const layer = layerRefs.current[layerName]
+      if (!layer) return
+      if (visibleLayers[layerName]) {
+        layer.addTo(map)
+      }
+    })
+
+    const analysisBounds = getAnalysisBounds(metadata)
+    studyAreaLayerRef.current = L.rectangle(analysisBounds, {
+      color: '#202124',
+      weight: 2,
+      fillOpacity: 0,
+      dashArray: '8 6',
+      pane: 'contextPane',
+    }).addTo(map)
+
+    const [, west] = analysisBounds[0]
+    const [north] = analysisBounds[1]
+    studyAreaLabelRef.current = L.marker([north - 0.03, west + 0.04], {
+      interactive: false,
+      icon: L.divIcon({
+        className: 'firewatch-study-label',
+        html: '<div class="firewatch-study-label__bubble">FRK study area</div>',
+      }),
+    }).addTo(map)
+
+    map.fitBounds(analysisBounds, { padding: [26, 26] })
+    setTimeout(() => map.invalidateSize(), 100)
+  }, [leafletReady, metadata, heritageData, burnData, graniteData, visibleLayers, heritageRiskFilter, heritageKindFilter])
 
   return (
-    <div className="flex h-full" style={{ background: '#F0EDE8' }}>
-      {/* Left Panel */}
-      <div className="w-72 bg-white border-r border-gray-200 flex flex-col px-6 py-6 overflow-y-auto flex-shrink-0">
-        
-        {/* Avatar + Title */}
-        <div className="flex items-center justify-between mb-6">
-          <h1 className="text-2xl font-black uppercase leading-tight tracking-tight">
-            Heritage Fire<br />Vulnerability<br />Model
-          </h1>
-          <div className="w-10 h-10 rounded-full bg-gray-800 flex items-center justify-center flex-shrink-0">
-            <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M12 12c2.7 0 4.8-2.1 4.8-4.8S14.7 2.4 12 2.4 7.2 4.5 7.2 7.2 9.3 12 12 12zm0 2.4c-3.2 0-9.6 1.6-9.6 4.8v2.4h19.2v-2.4c0-3.2-6.4-4.8-9.6-4.8z"/>
-            </svg>
-          </div>
+    <div className="firewatch-risk-page">
+      <aside className="firewatch-risk-page__panel">
+        <div className="firewatch-brand">
+          <p className="firewatch-brand__eyebrow">FRK heritage fire vulnerability</p>
+          <h1 className="firewatch-brand__title">FireWatch Heritage map</h1>
+          <p className="firewatch-brand__lede">
+            Prioritise heritage places by fuel exposure, slope, cultural sensitivity, and burn management context.
+          </p>
         </div>
 
-        {/* Search */}
-        <div className="flex items-center gap-2 border border-gray-300 rounded-full px-4 py-2 mb-8 bg-gray-50">
-          <svg className="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z" />
-          </svg>
-          <input
-            type="text"
-            placeholder="search"
-            className="bg-transparent text-sm outline-none w-full text-gray-600 placeholder-gray-400"
-          />
-        </div>
+        <section className="firewatch-summary" aria-label="Risk summary">
+          {summaryCards.map((card) => (
+            <div key={card.label} className="firewatch-summary__card">
+              <span>{card.value}</span>
+              <small>{card.label}</small>
+            </div>
+          ))}
+        </section>
 
-        {/* Sliders */}
-        <div className="flex flex-col gap-8">
+        <section className="firewatch-card" aria-label="Map layers">
+          <h2>Map Layers</h2>
+          {(
+            [
+              ['fire', 'Fire vulnerability'],
+              ['heritage', 'Heritage places'],
+              ['burn', 'Burn options'],
+              ['granite', 'Granite influence'],
+              ['fuel', 'Fuel type'],
+              ['slope', 'Slope'],
+            ] as Array<[LayerName, string]>
+          ).map(([layerName, label]) => (
+            <label key={layerName} className="firewatch-toggle-row">
+              <input
+                type="checkbox"
+                checked={visibleLayers[layerName]}
+                onChange={(event) =>
+                  setVisibleLayers((current) => ({
+                    ...current,
+                    [layerName]: event.target.checked,
+                  }))
+                }
+              />
+              {label}
+            </label>
+          ))}
+        </section>
 
-          {/* Topography */}
-          <div>
-            <p className="font-bold text-base mb-3">Topography (Slope)</p>
-            <input
-              type="range"
-              min={0}
-              max={45}
-              value={slope}
-              onChange={(e) => setSlope(Number(e.target.value))}
-              className="w-full accent-[#8B2020] h-1 cursor-pointer"
-            />
-            <p className="text-right text-sm text-gray-500 mt-1">{slope}°</p>
+        <section className="firewatch-card" aria-label="Layer colour key">
+          <h2>Layer Key</h2>
+
+          <div className="firewatch-key-group">
+            <h3>Fire Vulnerability</h3>
+            <div>
+              <span className="firewatch-key-box firewatch-key-box--high" />
+              <span>
+                High: <strong>{classification?.high ?? 'top risk areas'}</strong>
+              </span>
+            </div>
+            <div>
+              <span className="firewatch-key-box firewatch-key-box--medium" />
+              <span>
+                Medium: <strong>{classification?.medium ?? 'middle risk areas'}</strong>
+              </span>
+            </div>
+            <div>
+              <span className="firewatch-key-box firewatch-key-box--low" />
+              <span>
+                Low: <strong>{classification?.low ?? 'lower risk areas'}</strong>
+              </span>
+            </div>
           </div>
 
-          {/* Vegetation */}
-          <div>
-            <p className="font-bold text-base mb-3">Vegetation (Fuel Type)</p>
-            <select
-              value={fuelType}
-              onChange={(e) => setFuelType(e.target.value as FuelType)}
-              className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-700 bg-gray-50 outline-none focus:border-gray-400 focus:bg-white transition-colors cursor-pointer"
-            >
-              {FUEL_TYPES.map((t) => (
-                <option key={t} value={t}>{t}</option>
+          <div className="firewatch-key-group">
+            <h3>Fuel Type</h3>
+            <div>
+              <span className="firewatch-key-box firewatch-key-box--forest" />
+              <span>Forest / woodland</span>
+            </div>
+            <div>
+              <span className="firewatch-key-box firewatch-key-box--shrub" />
+              <span>Shrubland</span>
+            </div>
+            <div>
+              <span className="firewatch-key-box firewatch-key-box--grass" />
+              <span>Grassland / cropland</span>
+            </div>
+            <div>
+              <span className="firewatch-key-box firewatch-key-box--wet" />
+              <span>Wetland / water</span>
+            </div>
+            <div>
+              <span className="firewatch-key-box firewatch-key-box--urban" />
+              <span>Built-up / bare ground</span>
+            </div>
+          </div>
+
+          <div className="firewatch-key-group">
+            <h3>Slope</h3>
+            <div>
+              <span className="firewatch-key-box firewatch-key-box--slope-low" />
+              <span>Low</span>
+            </div>
+            <div>
+              <span className="firewatch-key-box firewatch-key-box--slope-mid" />
+              <span>Moderate</span>
+            </div>
+            <div>
+              <span className="firewatch-key-box firewatch-key-box--slope-high" />
+              <span>Steep</span>
+            </div>
+            <div>
+              <span className="firewatch-key-box firewatch-key-box--slope-vhigh" />
+              <span>Very steep</span>
+            </div>
+          </div>
+
+          <div className="firewatch-key-group">
+            <h3>Context Layers</h3>
+            <div>
+              <span className="firewatch-key-line firewatch-key-line--burn" />
+              <span>Burn option boundary</span>
+            </div>
+            <div>
+              <span className="firewatch-key-box firewatch-key-box--granite" />
+              <span>Granite influence</span>
+            </div>
+            <div>
+              <span className="firewatch-key-dot firewatch-key-dot--heritage" />
+              <span>Heritage place</span>
+            </div>
+          </div>
+        </section>
+
+        <section className="firewatch-controls" aria-label="Heritage filters">
+          <div className="firewatch-filter-set">
+            <p>Heritage risk filter</p>
+            <div className="firewatch-button-row">
+              {(['all', 'High', 'Medium', 'Low'] as const).map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  className={`firewatch-filter-button ${heritageRiskFilter === value ? 'is-active' : ''}`}
+                  onClick={() => setHeritageRiskFilter(value)}
+                >
+                  {value}
+                </button>
               ))}
-            </select>
+            </div>
           </div>
 
-          {/* Granite */}
-          <div>
-            <p className="font-bold text-base mb-3">Granite Influence</p>
-            <input
-              type="range"
-              min={0}
-              max={100}
-              value={graniteIndex}
-              onChange={(e) => setGraniteIndex(Number(e.target.value))}
-              className="w-full accent-[#8B2020] h-1 cursor-pointer"
-            />
-            <p className="text-right text-sm text-gray-500 mt-1">{graniteIndex}%</p>
+          <div className="firewatch-filter-set">
+            <p>Heritage type filter</p>
+            <div className="firewatch-button-row">
+              {(['all', 'Aboriginal', 'Non-Aboriginal'] as const).map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  className={`firewatch-filter-button ${heritageKindFilter === value ? 'is-active' : ''}`}
+                  onClick={() => setHeritageKindFilter(value)}
+                >
+                  {value}
+                </button>
+              ))}
+            </div>
           </div>
+        </section>
 
-        </div>
+        <section className="firewatch-card firewatch-details" aria-live="polite">
+          <h2>{details.title}</h2>
+          <p className="firewatch-details__intro">{details.intro}</p>
+          <dl className="firewatch-metric-list">
+            {details.metrics.map((metric) => (
+              <div key={metric.label} className="firewatch-metric">
+                <dt>{metric.label}</dt>
+                <dd>{metric.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
 
-        {/* Legend */}
-        <div className="mt-10 flex flex-col gap-3">
-          <div className="flex items-center gap-3">
-            <div className="w-3 h-3 rounded-full bg-[#8B2020] flex-shrink-0" />
-            <span className="text-sm font-medium">At Risk ( &lt;100m )</span>
-          </div>
-          <div className="flex items-center gap-3">
-            <div className="w-3 h-3 rounded-full bg-green-600 flex-shrink-0" />
-            <span className="text-sm font-medium">Low Risk ( &gt;100m )</span>
-          </div>
-        </div>
+        <section className="firewatch-card firewatch-method">
+          <h2>Score Method</h2>
+          <p>
+            <strong>Heritage score =</strong> fuel 45% + slope 25% + heritage type/material 25% + burn context 5%.
+          </p>
+          <p>
+            <strong>Area score =</strong> fuel 55% + slope 35% + granite influence 10%.
+          </p>
+          <p className="firewatch-method__note">
+            Unknown slope no longer produces High heritage risk; it is capped pending review.
+          </p>
+        </section>
+      </aside>
 
-      </div>
-
-      {/* Map placeholder */}
-      <div className="flex-1 bg-gray-100 flex items-center justify-center">
-        <p className="text-gray-400 text-sm">Map will be displayed here</p>
-      </div>
-
+      <section className="firewatch-map-wrap" aria-label="Interactive map">
+        <div ref={mapElementRef} id="firewatch-risk-map" />
+        {!leafletReady && !IS_TEST_ENV && !mapError && <div className="firewatch-map-overlay">Loading map engine…</div>}
+        {mapError && <div className="firewatch-map-overlay firewatch-map-overlay--error">{mapError}</div>}
+      </section>
     </div>
   )
 }

--- a/tests/frontend/app.test.tsx
+++ b/tests/frontend/app.test.tsx
@@ -10,6 +10,7 @@ describe('App', () => {
     expect(sidebar).not.toBeNull()
     expect(sidebar).toHaveTextContent(/Fire Vulnerability\s*Assessment Tool/)
     expect(screen.getByText('Risk Map')).toBeInTheDocument()
-    expect(screen.getByText('Map will be displayed here')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'FireWatch Heritage map' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Map Layers' })).toBeInTheDocument()
   })
 })

--- a/tests/frontend/risk_map.test.tsx
+++ b/tests/frontend/risk_map.test.tsx
@@ -1,0 +1,35 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import RiskMap from '../../src/pages/RiskMap'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('RiskMap page', () => {
+  it('renders the FireWatch MVP layout inside the Risk Map page', () => {
+    const { container } = render(<RiskMap />)
+    const pageHeading = container.querySelector('h1')
+
+    expect(pageHeading).not.toBeNull()
+    expect(pageHeading).toHaveTextContent(/FireWatch Heritage map/)
+    expect(screen.getByText(/Prioritise heritage places by fuel exposure/i)).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Map Layers' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Layer Key' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Score Method' })).toBeInTheDocument()
+    expect(screen.getByText('Heritage risk filter')).toBeInTheDocument()
+    expect(screen.getByText('Heritage type filter')).toBeInTheDocument()
+    expect(screen.getByText('Select a heritage place')).toBeInTheDocument()
+  })
+
+  it('keeps the expected default layer visibility toggles', () => {
+    render(<RiskMap />)
+
+    expect(screen.getByLabelText('Fire vulnerability')).toBeChecked()
+    expect(screen.getByLabelText('Heritage places')).toBeChecked()
+    expect(screen.getByLabelText('Burn options')).not.toBeChecked()
+    expect(screen.getByLabelText('Granite influence')).not.toBeChecked()
+    expect(screen.getByLabelText('Fuel type')).not.toBeChecked()
+    expect(screen.getByLabelText('Slope')).not.toBeChecked()
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/


### PR DESCRIPTION
- replace the placeholder Risk Map page with the FireWatch Heritage map MVP layout
- wire the page to the processed map assets already present in `main`
- add and update frontend tests for the new Risk Map baseline
- added `tests/frontend/risk_map.test.tsx`
- updated `tests/frontend/app.test.tsx` to match the new Risk Map baseline
- fixed the Vite test config import and removed an unused import in `src/main.tsx`


This test verifies that the updated Risk Map page:
- displays the title `FireWatch Heritage map`
- renders the `Map Layers` section
- renders the `Layer Key` section
- renders the `Score Method` section
- shows the heritage risk filter
- shows the heritage type filter
- applies the correct default layer toggle states on initial load
