### PR TITLE
feat(sidebar): add app and project partner logos & add test components

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -17,10 +17,26 @@ const Sidebar = () => {
     <aside className="w-56 bg-[#1A1A1A] text-white flex flex-col h-screen flex-shrink-0">
       {/* Logo */}
       <div className="px-4 py-5 border-b border-[#2A2A2A]">
-        <div className="text-xs font-extrabold tracking-widest uppercase leading-tight">
-          Fire Vulnerability<br />Assessment Tool
+        <div className="flex items-start gap-3">
+          <div className="w-12 h-12 rounded-lg bg-[#B03A2E] flex items-center justify-center shadow-sm shadow-black/20 flex-shrink-0">
+            <svg viewBox="0 0 64 64" className="w-8 h-8" aria-hidden="true">
+              <path
+                d="M32 8c7 9 16 15 16 28 0 10-7 18-16 18s-16-8-16-18c0-8 4-14 10-20 1 6 4 9 8 11-1-7 1-13 8-19Z"
+                fill="#F7F7F4"
+              />
+              <path
+                d="M32 28c4 5 8 8 8 14 0 5-4 9-8 9s-8-4-8-9c0-4 2-7 5-10 0 3 1 4 3 5 0-3 1-6 4-9Z"
+                fill="#1A1A1A"
+              />
+            </svg>
+          </div>
+          <div>
+            <div className="text-xs font-extrabold tracking-widest uppercase leading-tight">
+              Fire Vulnerability<br />Assessment Tool
+            </div>
+            <div className="text-[11px] text-gray-500 mt-1">Franklin District · WA</div>
+          </div>
         </div>
-        <div className="text-[11px] text-gray-500 mt-1">Franklin District · WA</div>
       </div>
 
       {/* Nav */}
@@ -51,8 +67,37 @@ const Sidebar = () => {
       </nav>
 
       {/* Footer */}
-      <div className="px-4 py-3 border-t border-[#2A2A2A] text-[11px] text-gray-600">
-        Franklin District · FRK<br />v1.0 Pilot
+      <div className="px-4 py-3 border-t border-[#2A2A2A]">
+        <div className="text-[10px] font-bold tracking-widest uppercase text-gray-600 mb-2">
+          Project Partners
+        </div>
+        <div className="space-y-2 mb-3">
+          <div className="flex items-center gap-2 rounded-md border border-[#2A2A2A] bg-[#202020] px-2 py-2">
+            <img
+              src="https://images.squarespace-cdn.com/content/v1/61f8e2c584741255f5ca8798/290d1715-85eb-4c72-a7e6-9c59ca2501ca/WKSNLogo.png"
+              alt="Wagyl Kaip South Noongar logo"
+              className="w-7 h-7 rounded object-contain bg-white p-0.5 flex-shrink-0"
+            />
+            <div>
+              <div className="text-[11px] font-semibold text-white leading-tight">Wagyl Kaip</div>
+              <div className="text-[10px] text-gray-500 leading-tight">Project Partner</div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 rounded-md border border-[#2A2A2A] bg-[#202020] px-2 py-2">
+            <img
+              src="https://www.uwa.edu.au/_assets/favicon512.png"
+              alt="University of Western Australia logo"
+              className="w-7 h-7 rounded object-contain bg-white p-0.5 flex-shrink-0"
+            />
+            <div>
+              <div className="text-[11px] font-semibold text-white leading-tight">University of Western Australia</div>
+              <div className="text-[10px] text-gray-500 leading-tight">Project Partner</div>
+            </div>
+          </div>
+        </div>
+        <div className="text-[11px] text-gray-600">
+          Franklin District · FRK<br />v1.0 Pilot
+        </div>
       </div>
     </aside>
   )

--- a/tests/frontend/sidebar.test.tsx
+++ b/tests/frontend/sidebar.test.tsx
@@ -15,6 +15,9 @@ describe('Sidebar', () => {
     expect(sidebar).not.toBeNull()
     expect(sidebar).toHaveTextContent(/Fire Vulnerability\s*Assessment Tool/)
     expect(screen.getByText('Franklin District · WA')).toBeInTheDocument()
+    expect(screen.getByText('Project Partners')).toBeInTheDocument()
+    expect(screen.getByText('Wagyl Kaip')).toBeInTheDocument()
+    expect(screen.getByText('University of Western Australia')).toBeInTheDocument()
 
     expect(screen.getByRole('link', { name: 'Risk Map' })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Model Insights' })).toBeInTheDocument()


### PR DESCRIPTION
- added an app logo to the sidebar header
- added a `Project Partners` section to the sidebar footer
- added the official logos for Wagyl Kaip and the University of Western Australia
- updated `tests/frontend/sidebar.test.tsx` to cover the new sidebar branding content
