### PR TITLE
Add slope classification ranges to Risk Map UI

### DIFF
--- a/src/pages/RiskMap.css
+++ b/src/pages/RiskMap.css
@@ -386,3 +386,10 @@
     min-height: 70vh;
   }
 }
+
+.firewatch-key-helper {
+  margin: -0.15rem 0 0.65rem;
+  color: #6b7280;
+  font-size: 0.78rem;
+  line-height: 1.35;
+}

--- a/src/pages/RiskMap.tsx
+++ b/src/pages/RiskMap.tsx
@@ -745,25 +745,25 @@ function RiskMap() {
             </div>
           </div>
 
-          <div className="firewatch-key-group">
-            <h3>Slope</h3>
-            <div>
-              <span className="firewatch-key-box firewatch-key-box--slope-low" />
-              <span>Low</span>
-            </div>
-            <div>
-              <span className="firewatch-key-box firewatch-key-box--slope-mid" />
-              <span>Moderate</span>
-            </div>
-            <div>
-              <span className="firewatch-key-box firewatch-key-box--slope-high" />
-              <span>Steep</span>
-            </div>
-            <div>
-              <span className="firewatch-key-box firewatch-key-box--slope-vhigh" />
-              <span>Very steep</span>
-            </div>
-          </div>
+         <div className="firewatch-key-group">
+  <h3>Slope</h3>
+  <div>
+    <span className="firewatch-key-box firewatch-key-box--slope-low" />
+    <span>0-5°: Low slope</span>
+  </div>
+  <div>
+    <span className="firewatch-key-box firewatch-key-box--slope-mid" />
+    <span>5-15°: Moderate slope</span>
+  </div>
+  <div>
+    <span className="firewatch-key-box firewatch-key-box--slope-high" />
+    <span>15-25°: Steep slope</span>
+  </div>
+  <div>
+    <span className="firewatch-key-box firewatch-key-box--slope-vhigh" />
+    <span>25°+: Very steep slope</span>
+  </div>
+</div>
 
           <div className="firewatch-key-group">
             <h3>Context Layers</h3>

--- a/src/pages/RiskMap.tsx
+++ b/src/pages/RiskMap.tsx
@@ -747,6 +747,9 @@ function RiskMap() {
 
          <div className="firewatch-key-group">
   <h3>Slope</h3>
+  <p className="firewatch-key-helper">
+  Slope ranges indicate terrain steepness for interpreting the slope overlay.
+</p>
   <div>
     <span className="firewatch-key-box firewatch-key-box--slope-low" />
     <span>0-5°: Low slope</span>


### PR DESCRIPTION
This PR adds visible slope range classification information to the Risk Map UI.

Changes:
- Added slope classification ranges to the Slope section in the Layer Key.
- Updated the UI to show 0-5° as Low slope, 5-15° as Moderate slope, 15-25° as Steep slope, and 25°+ as Very steep slope.
- Added a short explanation to help users interpret the slope overlay.

Testing:
- Ran npm run dev.
- Confirmed the Risk Map page loads successfully.
- Confirmed the slope classification ranges are visible in the Layer Key.
- Confirmed the existing map legend and layer controls still display correctly.