### PR TITLE
feat: Login page routing, layout refactor & branding alignment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,24 +5,34 @@ import ModelInsights from './pages/ModelInsights'
 import FireRegulation from './pages/FireRegulation'
 import HeritagRegistry from './pages/HeritagRegistry'
 import SiteAssessment from './pages/SiteAssessment'
+import Login from './pages/Login'
+
+const MainLayout = () => {
+  return (
+    <div className="flex h-screen bg-[#F5F0E8]">
+      <Sidebar />
+      <main className="flex-1 overflow-y-auto">
+        <Routes>
+          <Route path="/" element={<RiskMap />} />
+          <Route path="/insights" element={<ModelInsights />} />
+          <Route path="/regulation" element={<FireRegulation />} />
+          <Route path="/registry" element={<HeritagRegistry />} />
+          <Route path="/assessment" element={<SiteAssessment />} />
+        </Routes>
+      </main>
+    </div>
+  )
+}
 
 const App = () => {
   return (
-    <BrowserRouter
-    
-    >
-      <div className="flex h-screen bg-[#F5F0E8]">
-        <Sidebar />
-        <main className="flex-1 overflow-y-auto">
-          <Routes>
-            <Route path="/" element={<RiskMap />} />
-            <Route path="/insights" element={<ModelInsights />} />
-            <Route path="/regulation" element={<FireRegulation />} />
-            <Route path="/registry" element={<HeritagRegistry />} />
-            <Route path="/assessment" element={<SiteAssessment />} />
-          </Routes>
-        </main>
-      </div>
+    <BrowserRouter>
+      <Routes>
+        {/* Login page rendered without sidebar layout */}
+        <Route path="/login" element={<Login />} />
+        {/* All other routes use the main layout (sidebar + content) */}
+        <Route path="/*" element={<MainLayout />} />
+      </Routes>
     </BrowserRouter>
   )
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -6,15 +6,24 @@ const Login = () => {
       <div className="bg-[#1A1A1A] px-12 py-12 flex flex-col justify-between">
         <div>
           {/* Brand */}
-          <div className="flex items-center gap-3 mb-12">
-            <div className="w-9 h-9 bg-[#8B2020] rounded-lg flex items-center justify-center flex-shrink-0">
-              <svg width="20" height="22" viewBox="0 0 20 22" fill="none">
-                <path d="M10 0C10 0 4 5 3 10C2 13 3 15 4 16C4 13 6 11 6 11C6 14 7 16 9 17C8 15 9 13 10 12C11 13 12 15 11 17C13 16 14 14 14 11C14 11 16 13 16 16C17 15 18 13 17 10C16 5 10 0 10 0Z" fill="white"/>
-                <path d="M10 22C12.2 22 14 20.2 14 18C14 15.8 10 13 10 13C10 13 6 15.8 6 18C6 20.2 7.8 22 10 22Z" fill="white" opacity=".7"/>
+          <div className="flex items-start gap-3 mb-12">
+            <div className="w-12 h-12 rounded-lg bg-[#B03A2E] flex items-center justify-center shadow-sm shadow-black/20 flex-shrink-0">
+              <svg viewBox="0 0 64 64" className="w-8 h-8" aria-hidden="true">
+                <path
+                  d="M32 8c7 9 16 15 16 28 0 10-7 18-16 18s-16-8-16-18c0-8 4-14 10-20 1 6 4 9 8 11-1-7 1-13 8-19Z"
+                  fill="#F7F7F4"
+                />
+                <path
+                  d="M32 28c4 5 8 8 8 14 0 5-4 9-8 9s-8-4-8-9c0-4 2-7 5-10 0 3 1 4 3 5 0-3 1-6 4-9Z"
+                  fill="#1A1A1A"
+                />
               </svg>
             </div>
-            <div className="text-xs font-extrabold text-white uppercase tracking-widest leading-tight">
-              Fire Vulnerability<br />Assessment Tool
+            <div>
+              <div className="text-xs font-extrabold text-white uppercase tracking-widest leading-tight">
+                Fire Vulnerability<br />Assessment Tool
+              </div>
+              <div className="text-[11px] text-gray-500 mt-1">Franklin District · WA</div>
             </div>
           </div>
 
@@ -44,8 +53,41 @@ const Login = () => {
           </div>
         </div>
 
-        <div className="text-xs text-gray-700">
-          © 2026 Fire Vulnerability Assessment Tool · Franklin District
+        <div>
+          {/* Project Partners */}
+          <div className="mb-6">
+            <div className="text-[10px] font-bold tracking-widest uppercase text-gray-600 mb-2">
+              Project Partners
+            </div>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 rounded-md border border-[#2A2A2A] bg-[#202020] px-2 py-2">
+                <img
+                  src="https://images.squarespace-cdn.com/content/v1/61f8e2c584741255f5ca8798/290d1715-85eb-4c72-a7e6-9c59ca2501ca/WKSNLogo.png"
+                  alt="Wagyl Kaip South Noongar logo"
+                  className="w-7 h-7 rounded object-contain bg-white p-0.5 flex-shrink-0"
+                />
+                <div>
+                  <div className="text-[11px] font-semibold text-white leading-tight">Wagyl Kaip</div>
+                  <div className="text-[10px] text-gray-500 leading-tight">Project Partner</div>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 rounded-md border border-[#2A2A2A] bg-[#202020] px-2 py-2">
+                <img
+                  src="https://www.uwa.edu.au/_assets/favicon512.png"
+                  alt="University of Western Australia logo"
+                  className="w-7 h-7 rounded object-contain bg-white p-0.5 flex-shrink-0"
+                />
+                <div>
+                  <div className="text-[11px] font-semibold text-white leading-tight">University of Western Australia</div>
+                  <div className="text-[10px] text-gray-500 leading-tight">Project Partner</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="text-xs text-gray-700">
+            © 2026 Fire Vulnerability Assessment Tool · Franklin District
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
This PR sets up the `/login` route and refactors the app layout to support full-screen pages, then aligns the Login page branding with the Sidebar for visual consistency.

## Changes

**Routing & Layout Refactor**
- Registered the Login page at `/login` route
- Extracted sidebar + content structure into a `MainLayout` component
- Rendered Login outside of `MainLayout` to support its full-screen two-column layout (no sidebar)

**Login Page Branding**
- Replaced Login logo with the Sidebar's flame icon and red badge (`w-12 h-12`, `#B03A2E`)
- Added "Franklin District · WA" subtitle under the brand title
- Added Project Partners footer (Wagyl Kaip, University of Western Australia) above the copyright line, matching Sidebar styling

## Testing
- [ ] `/login` route is accessible and renders correctly
- [ ] Sidebar does not appear on the Login page
- [ ] Branding elements match the Sidebar visually
- [ ] Other routes still render within `MainLayout` as expected