### PR TITLE
Add SQLite-backed layer APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 # Python
 __pycache__/
 *.py[cod]
+.venv/
 
 node_modules
 dist

--- a/backend/API_DOCS.md
+++ b/backend/API_DOCS.md
@@ -113,7 +113,54 @@ Example Error Response
   "error": "fuelRisk must be between 0 and 100"
 }
 ```
+5. Heritage Sites
+Endpoint
+```
+GET /api/heritage
+GET /api/sites
+```
+Purpose
+
+Returns heritage site records from the local SQLite database.
+
+Example Response
+```JSON
+{
+  "count": 268,
+  "sites": []
+}
+```
+
+Single site lookup
+```
+GET /api/heritage/<site_id>
+GET /api/sites/<site_id>
+```
+
+6. Processed Map Layers
+Endpoints
+```
+GET /api/layers/heritage
+GET /api/layers/burn-options
+GET /api/layers/granite
+```
+Purpose
+
+Returns page-ready GeoJSON FeatureCollections from SQLite. These correspond to
+the processed heritage, burn option, and granite layers used by the map and
+registry pages.
+
+7. Processed Metadata
+Endpoint
+```
+GET /api/processed-metadata
+```
+Purpose
+
+Returns processed map metadata from SQLite, including analysis bounds, layer
+counts, raster overlay filenames, and score formula details.
+
 Notes
 
-The backend currently provides metadata and site assessment support.
-Map visualisation and layer display are handled by the frontend, while the backend provides model data and assessment results.
+The backend now provides SQLite-backed heritage, processed metadata, and
+processed map layer endpoints. Raster overlay image files remain static files.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, jsonify, request
 from flask_cors import CORS
 
+from routes.heritage_routes import heritage_bp
 from services.site_assessment import calculate_site_score, get_risk_level
 
 from pathlib import Path
@@ -8,6 +9,7 @@ import json
 
 app = Flask(__name__)
 CORS(app)
+app.register_blueprint(heritage_bp)
 
 BASE_DIR = Path(__file__).resolve().parent
 METADATA_FILE = BASE_DIR / "data" / "metadata.json"

--- a/backend/routes/heritage_routes.py
+++ b/backend/routes/heritage_routes.py
@@ -1,6 +1,11 @@
 from flask import Blueprint, jsonify
 
-from services.data_loader import find_record_by_id, load_json_data
+from services.data_loader import (
+    get_geojson_layer,
+    get_heritage_site_by_id,
+    get_heritage_sites as load_heritage_sites_from_db,
+    get_processed_metadata,
+)
 
 
 heritage_bp = Blueprint("heritage", __name__, url_prefix="/api")
@@ -10,11 +15,9 @@ heritage_bp = Blueprint("heritage", __name__, url_prefix="/api")
 @heritage_bp.route("/sites", methods=["GET"])
 def get_heritage_sites():
     try:
-        sites = load_json_data("heritage_sites.json")
-    except FileNotFoundError:
-        return jsonify({"error": "heritage_sites.json not found"}), 404
-    except ValueError:
-        return jsonify({"error": "heritage_sites.json is invalid"}), 500
+        sites = load_heritage_sites_from_db()
+    except Exception as error:
+        return jsonify({"error": f"could not load heritage sites: {error}"}), 500
 
     return jsonify({
         "count": len(sites),
@@ -26,14 +29,36 @@ def get_heritage_sites():
 @heritage_bp.route("/sites/<site_id>", methods=["GET"])
 def get_heritage_site(site_id):
     try:
-        sites = load_json_data("heritage_sites.json")
-    except FileNotFoundError:
-        return jsonify({"error": "heritage_sites.json not found"}), 404
-    except ValueError:
-        return jsonify({"error": "heritage_sites.json is invalid"}), 500
+        site = get_heritage_site_by_id(site_id)
+    except Exception as error:
+        return jsonify({"error": f"could not load heritage site: {error}"}), 500
 
-    site = find_record_by_id(sites, site_id)
     if site is None:
         return jsonify({"error": "heritage site not found"}), 404
 
     return jsonify(site)
+
+
+@heritage_bp.route("/layers/heritage", methods=["GET"])
+def get_heritage_layer():
+    return jsonify(get_geojson_layer("heritage_all"))
+
+
+@heritage_bp.route("/layers/burn-options", methods=["GET"])
+@heritage_bp.route("/layers/burn_options", methods=["GET"])
+def get_burn_options_layer():
+    return jsonify(get_geojson_layer("burn_options"))
+
+
+@heritage_bp.route("/layers/granite", methods=["GET"])
+def get_granite_layer():
+    return jsonify(get_geojson_layer("granite"))
+
+
+@heritage_bp.route("/processed-metadata", methods=["GET"])
+def get_processed_metadata_route():
+    metadata = get_processed_metadata()
+    if metadata is None:
+        return jsonify({"error": "processed metadata not found"}), 404
+
+    return jsonify(metadata)

--- a/backend/services/data_loader.py
+++ b/backend/services/data_loader.py
@@ -1,9 +1,11 @@
-from pathlib import Path
 import json
+import sqlite3
+from pathlib import Path
 
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 DATA_DIR = BASE_DIR / "data"
+DEFAULT_DB_PATH = DATA_DIR / "firewatch.sqlite"
 
 
 def load_json_data(filename):
@@ -18,3 +20,108 @@ def find_record_by_id(records, record_id):
         if record.get("id") == record_id:
             return record
     return None
+
+
+def get_db_connection(db_path=DEFAULT_DB_PATH):
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    return connection
+
+
+def row_to_heritage_site(row):
+    return {
+        "id": row["id"],
+        "identifier": row["identifier"],
+        "name": row["name"],
+        "source": row["source"],
+        "geometry": json.loads(row["geometry_json"]) if row["geometry_json"] else None,
+        "properties": json.loads(row["properties_json"]) if row["properties_json"] else {},
+        "coordinates": {
+            "latitude": row["latitude"],
+            "longitude": row["longitude"],
+        },
+        "heritageType": row["heritage_type"],
+        "fuelClass": row["fuel_class"],
+        "slopeDegrees": row["slope_degrees"],
+        "vulnerabilityScore": row["vulnerability_score"],
+        "vulnerabilityLevel": row["vulnerability_level"],
+        "assessedDate": row["assessed_date"],
+        "createdBy": row["created_by"],
+        "createdAt": row["created_at"],
+        "updatedAt": row["updated_at"],
+    }
+
+
+def get_heritage_sites():
+    with get_db_connection() as connection:
+        rows = connection.execute(
+            """
+            SELECT *
+            FROM heritage_sites
+            ORDER BY name COLLATE NOCASE
+            """
+        ).fetchall()
+
+    return [row_to_heritage_site(row) for row in rows]
+
+
+def get_heritage_site_by_id(site_id):
+    with get_db_connection() as connection:
+        row = connection.execute(
+            """
+            SELECT *
+            FROM heritage_sites
+            WHERE id = ? OR identifier = ?
+            LIMIT 1
+            """,
+            (site_id, site_id),
+        ).fetchone()
+
+    return row_to_heritage_site(row) if row else None
+
+
+def get_geojson_layer(layer_name):
+    with get_db_connection() as connection:
+        rows = connection.execute(
+            """
+            SELECT feature_id, geometry_json, properties_json
+            FROM geojson_features
+            WHERE layer_name = ?
+            ORDER BY feature_index
+            """,
+            (layer_name,),
+        ).fetchall()
+
+    features = []
+    for row in rows:
+        properties = json.loads(row["properties_json"])
+        features.append({
+            "type": "Feature",
+            "id": row["feature_id"],
+            "geometry": json.loads(row["geometry_json"]),
+            "properties": properties,
+        })
+
+    return {
+        "type": "FeatureCollection",
+        "name": layer_name,
+        "features": features,
+    }
+
+
+def get_processed_metadata():
+    with get_db_connection() as connection:
+        row = connection.execute(
+            """
+            SELECT value_json
+            FROM app_metadata
+            WHERE key = ?
+            LIMIT 1
+            """,
+            ("processed_metadata",),
+        ).fetchone()
+
+    if row is None:
+        return None
+    return json.loads(row["value_json"])


### PR DESCRIPTION
Additional update:
- Add SQLite-backed backend APIs for `/api/heritage`, processed GeoJSON layers, and processed metadata.
- Register the heritage blueprint in Flask.
- Document the new endpoints in `backend/API_DOCS.md`.

Verified with Flask test client:
- `/api/heritage` -> 268 records
- `/api/layers/heritage` -> 268 features
- `/api/layers/burn-options` -> 24 features
- `/api/layers/granite` -> 12 features
- `/api/processed-metadata` -> 268 heritage features
