### PR TITLE
Add heritage data source mapping

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS heritage_sites (
     identifier TEXT UNIQUE,
     name TEXT NOT NULL,
     source TEXT,
+    data_source TEXT,
     geometry_json TEXT NOT NULL,
     properties_json TEXT,
     latitude REAL,
@@ -35,7 +36,8 @@ CREATE TABLE IF NOT EXISTS heritage_sites (
     updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
     CHECK (vulnerability_score IS NULL OR (vulnerability_score >= 0 AND vulnerability_score <= 100)),
-    CHECK (vulnerability_level IS NULL OR vulnerability_level IN ('Low', 'Medium', 'High'))
+    CHECK (vulnerability_level IS NULL OR vulnerability_level IN ('Low', 'Medium', 'High')),
+    CHECK (data_source IS NULL OR data_source IN ('DPLH_099', 'DPLH_100', 'DPLH_006'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_heritage_sites_identifier
@@ -43,6 +45,9 @@ CREATE INDEX IF NOT EXISTS idx_heritage_sites_identifier
 
 CREATE INDEX IF NOT EXISTS idx_heritage_sites_source
     ON heritage_sites(source);
+
+CREATE INDEX IF NOT EXISTS idx_heritage_sites_data_source
+    ON heritage_sites(data_source);
 
 CREATE INDEX IF NOT EXISTS idx_heritage_sites_lat_lon
     ON heritage_sites(latitude, longitude);

--- a/backend/scripts/init_sqlite_db.py
+++ b/backend/scripts/init_sqlite_db.py
@@ -30,9 +30,27 @@ def ensure_column(
 
 
 def apply_lightweight_migrations(connection: sqlite3.Connection) -> None:
+    ensure_column(connection, "heritage_sites", "data_source", "TEXT")
     ensure_column(connection, "heritage_sites", "properties_json", "TEXT")
     ensure_column(connection, "burn_options", "properties_json", "TEXT")
     ensure_column(connection, "granite_polygons", "properties_json", "TEXT")
+
+
+def table_exists(connection: sqlite3.Connection, table_name: str) -> bool:
+    row = connection.execute(
+        """
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table' AND name = ?
+        """,
+        (table_name,),
+    ).fetchone()
+    return row is not None
+
+
+def apply_pre_schema_migrations(connection: sqlite3.Connection) -> None:
+    if table_exists(connection, "heritage_sites"):
+        ensure_column(connection, "heritage_sites", "data_source", "TEXT")
 
 
 def initialise_database(db_path: Path, schema_path: Path) -> None:
@@ -41,6 +59,7 @@ def initialise_database(db_path: Path, schema_path: Path) -> None:
 
     with sqlite3.connect(db_path) as connection:
         connection.execute("PRAGMA foreign_keys = ON")
+        apply_pre_schema_migrations(connection)
         connection.executescript(schema_sql)
         apply_lightweight_migrations(connection)
 

--- a/backend/scripts/seed_sqlite_db.py
+++ b/backend/scripts/seed_sqlite_db.py
@@ -47,6 +47,20 @@ def risk_level(score: int | float | None) -> str | None:
     return "Low"
 
 
+def heritage_data_source(source: str | None) -> str | None:
+    if source is None:
+        return None
+
+    normalized = source.strip().lower().replace("_", " ")
+    if normalized == "register":
+        return "DPLH_099"
+    if normalized == "lodged":
+        return "DPLH_100"
+    if normalized == "state register":
+        return "DPLH_006"
+    return None
+
+
 def load_feature_collection(path: Path) -> list[dict[str, Any]]:
     data = json.loads(path.read_text(encoding="utf-8"))
     if data.get("type") != "FeatureCollection":
@@ -165,6 +179,7 @@ def seed_heritage_sites(
                 identifier,
                 name,
                 source,
+                data_source,
                 geometry_json,
                 properties_json,
                 latitude,
@@ -177,11 +192,12 @@ def seed_heritage_sites(
                 assessed_date,
                 created_by
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 identifier = excluded.identifier,
                 name = excluded.name,
                 source = excluded.source,
+                data_source = excluded.data_source,
                 geometry_json = excluded.geometry_json,
                 properties_json = excluded.properties_json,
                 latitude = excluded.latitude,
@@ -199,6 +215,7 @@ def seed_heritage_sites(
                 identifier,
                 props.get("name") or "Unnamed heritage site",
                 props.get("source"),
+                heritage_data_source(props.get("source")),
                 json.dumps(geometry, separators=(",", ":")),
                 json.dumps(props, separators=(",", ":")),
                 latitude,

--- a/backend/services/data_loader.py
+++ b/backend/services/data_loader.py
@@ -35,6 +35,7 @@ def row_to_heritage_site(row):
         "identifier": row["identifier"],
         "name": row["name"],
         "source": row["source"],
+        "dataSource": row["data_source"],
         "geometry": json.loads(row["geometry_json"]) if row["geometry_json"] else None,
         "properties": json.loads(row["properties_json"]) if row["properties_json"] else {},
         "coordinates": {


### PR DESCRIPTION
## Summary
- Add `data_source` to `heritage_sites`
- Map source values to dataset codes:
  - `Register` -> `DPLH_099`
  - `Lodged` -> `DPLH_100`
  - `State Register` -> `DPLH_006`
- Include `dataSource` in heritage API responses

## Verification
- `python3 -m py_compile backend/scripts/init_sqlite_db.py backend/scripts/seed_sqlite_db.py backend/services/data_loader.py`
- Verified local SQLite mapping counts:
  - `Register` / `DPLH_099`: 60
  - `Lodged` / `DPLH_100`: 107
  - `State Register` / `DPLH_006`: 101
