### PR TITLE
test(backend): add API smoke, auth, assessment and contract tests

### DIFF
--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+BACKEND_DIR = ROOT_DIR / "backend"
+
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+import app as app_module  # noqa: E402
+
+
+@pytest.fixture()
+def client():
+    app_module.app.config.update(TESTING=True)
+    with app_module.app.test_client() as test_client:
+        yield test_client

--- a/tests/backend/test_app_smoke.py
+++ b/tests/backend/test_app_smoke.py
@@ -1,0 +1,15 @@
+def test_home_returns_running_message(client):
+    response = client.get("/")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload == {"message": "Backend is running"}
+
+
+def test_metadata_endpoint_returns_json(client):
+    response = client.get("/api/metadata")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert isinstance(payload, dict)
+    assert len(payload) > 0

--- a/tests/backend/test_auth_and_assessment.py
+++ b/tests/backend/test_auth_and_assessment.py
@@ -1,0 +1,47 @@
+def test_register_rejects_invalid_email(client):
+    response = client.post(
+        "/api/register",
+        json={"username": "test", "email": "not-an-email", "password": "secret12"},
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["error"] == "Invalid email format"
+
+
+def test_register_accepts_valid_input(client):
+    response = client.post(
+        "/api/register",
+        json={"username": "test", "email": "test@example.com", "password": "secret12"},
+    )
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["user"]["email"] == "test@example.com"
+
+
+def test_site_assessment_validates_required_fields(client):
+    response = client.post("/api/site-assessment", json={"fuelRisk": 50})
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert "is required" in payload["error"]
+
+
+def test_site_assessment_returns_score_and_level(client):
+    response = client.post(
+        "/api/site-assessment",
+        json={
+            "fuelRisk": 100,
+            "slopeRisk": 0,
+            "heritageTypeRisk": 0,
+            "burnContext": 0,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+
+    assert payload["score"] == 45
+    assert payload["riskLevel"] == "Low"
+    assert payload["breakdown"]["fuelRisk"] == 100

--- a/tests/backend/test_backend_contracts.py
+++ b/tests/backend/test_backend_contracts.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _load_backend_json(relative_path: str):
+    root_dir = Path(__file__).resolve().parents[2]
+    file_path = root_dir / "backend" / relative_path
+    assert file_path.exists(), f"Missing required data file: {file_path}"
+    return json.loads(file_path.read_text(encoding="utf-8"))
+
+
+def test_required_metadata_json_exists_and_is_valid():
+    payload = _load_backend_json("data/metadata.json")
+    assert isinstance(payload, dict)
+    assert "score_formula" in payload
+
+
+def test_required_heritage_sites_json_exists_and_is_valid():
+    payload = _load_backend_json("data/heritage_sites.json")
+    assert isinstance(payload, list)
+    assert len(payload) > 0
+    first = payload[0]
+    assert "id" in first
+    assert "name" in first
+    assert "coordinates" in first
+
+
+def test_score_formula_weights_sum_to_one():
+    metadata = _load_backend_json("data/metadata.json")
+    formula = metadata["score_formula"]
+
+    heritage_weights = formula["heritage_vulnerability"]
+    area_weights = formula["area_vulnerability"]
+
+    assert abs(sum(heritage_weights.values()) - 1.0) < 1e-9
+    assert abs(sum(area_weights.values()) - 1.0) < 1e-9
+
+
+def test_site_assessment_scoring_matches_metadata_weights():
+    from services.site_assessment import calculate_site_score
+
+    metadata = _load_backend_json("data/metadata.json")
+    weights = metadata["score_formula"]["heritage_vulnerability"]
+
+    fuel = 10
+    slope = 20
+    heritage = 30
+    burn = 40
+
+    expected = round(
+        fuel * weights["fuel_risk"]
+        + slope * weights["slope_risk"]
+        + heritage * weights["heritage_type_material_risk"]
+        + burn * weights["burn_management_context"]
+    )
+
+    assert calculate_site_score(fuel, slope, heritage, burn) == expected
+
+
+def test_fire_classification_mappings_exist():
+    from services import risk_normalization
+
+    assert isinstance(risk_normalization.FUEL_TYPE_RISK, dict)
+    assert len(risk_normalization.FUEL_TYPE_RISK) > 0
+    assert "Tall closed forest" in risk_normalization.FUEL_TYPE_RISK
+
+    assert isinstance(risk_normalization.HERITAGE_TYPE_MATERIAL_RISK, dict)
+    assert len(risk_normalization.HERITAGE_TYPE_MATERIAL_RISK) > 0
+
+    assert isinstance(risk_normalization.BURN_CONTEXT_RISK, dict)
+    assert "inside_burn_option" in risk_normalization.BURN_CONTEXT_RISK


### PR DESCRIPTION
Title: Backend: add API smoke + auth/assessment + data contract tests

Summary
This PR adds backend tests covering core API endpoints and enforcing basic data/contract invariants to prevent regressions in routing, validation, and scoring.

What changed
- Added a shared Flask test client fixture and ensured backend imports work in tests (tests/backend/conftest.py).
- Added smoke tests for:
  - GET / returns {"message": "Backend is running"}
  - GET /api/metadata returns non-empty JSON (tests/backend/test_app_smoke.py).
- Added endpoint validation tests for:
  - POST /api/register rejects invalid email and accepts valid input (tests/backend/test_auth_and_assessment.py).
  - POST /api/site-assessment validates required fields and returns deterministic score + riskLevel for a known payload (tests/backend/test_auth_and_assessment.py).
- Added contract tests for backend JSON and scoring logic:
  - metadata.json exists and contains score_formula
  - heritage_sites.json exists and has required fields
  - score formula weight groups sum to 1.0
  - calculate_site_score matches metadata weights for a sample input
  - risk normalization mappings exist (tests/backend/test_backend_contracts.py).

- Ensures key backend endpoints remain functional.
- Locks in expected validation behavior for register and site assessment.
- Guards against accidental changes to scoring weights and required data file structure.

How to test
- Run: pytest tests/backend -q

Notes
- These tests depend on backend data files being present under backend/data (metadata.json and heritage_sites.json).