### PR TITLE
Add user-submitted heritage site create and delete flow

### DIFF
--- a/backend/routes/heritage_routes.py
+++ b/backend/routes/heritage_routes.py
@@ -1,7 +1,10 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 
 from services.data_loader import (
+    create_heritage_site,
+    delete_user_heritage_site,
     get_geojson_layer,
+    get_heritage_registry_layer,
     get_heritage_site_by_id,
     get_heritage_sites as load_heritage_sites_from_db,
     get_processed_metadata,
@@ -25,6 +28,26 @@ def get_heritage_sites():
     })
 
 
+@heritage_bp.route("/heritage", methods=["POST"])
+@heritage_bp.route("/sites", methods=["POST"])
+def add_heritage_site():
+    data = request.get_json()
+    if data is None:
+        return jsonify({"error": "Request body must be valid JSON"}), 400
+
+    try:
+        site, feature = create_heritage_site(data)
+    except ValueError as error:
+        return jsonify({"error": str(error)}), 400
+    except Exception as error:
+        return jsonify({"error": f"could not create heritage site: {error}"}), 500
+
+    return jsonify({
+        "site": site,
+        "feature": feature,
+    }), 201
+
+
 @heritage_bp.route("/heritage/<site_id>", methods=["GET"])
 @heritage_bp.route("/sites/<site_id>", methods=["GET"])
 def get_heritage_site(site_id):
@@ -37,6 +60,27 @@ def get_heritage_site(site_id):
         return jsonify({"error": "heritage site not found"}), 404
 
     return jsonify(site)
+
+
+@heritage_bp.route("/heritage/<site_id>", methods=["DELETE"])
+@heritage_bp.route("/sites/<site_id>", methods=["DELETE"])
+def delete_heritage_site(site_id):
+    try:
+        result = delete_user_heritage_site(site_id)
+    except Exception as error:
+        return jsonify({"error": f"could not delete heritage site: {error}"}), 500
+
+    if result == "not_found":
+        return jsonify({"error": "heritage site not found"}), 404
+    if result == "not_user_site":
+        return jsonify({"error": "only user-submitted heritage sites can be deleted"}), 403
+
+    return jsonify({"deleted": True, "id": site_id})
+
+
+@heritage_bp.route("/heritage-registry", methods=["GET"])
+def get_heritage_registry():
+    return jsonify(get_heritage_registry_layer())
 
 
 @heritage_bp.route("/layers/heritage", methods=["GET"])

--- a/backend/services/data_loader.py
+++ b/backend/services/data_loader.py
@@ -1,5 +1,7 @@
 import json
 import sqlite3
+import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -54,6 +56,48 @@ def row_to_heritage_site(row):
     }
 
 
+def row_to_heritage_feature(row):
+    properties = json.loads(row["properties_json"]) if row["properties_json"] else {}
+    properties.update({
+        "id": row["identifier"] or row["id"],
+        "identifier": row["identifier"] or row["id"],
+        "name": row["name"],
+        "source": row["source"],
+        "data_source": row["data_source"],
+        "longitude": row["longitude"],
+        "latitude": row["latitude"],
+        "place_type": row["heritage_type"],
+        "fuel_class": row["fuel_class"],
+        "slope_degrees": row["slope_degrees"],
+        "vulnerability_score": row["vulnerability_score"],
+        "vulnerability_level": row["vulnerability_level"],
+    })
+
+    return {
+        "type": "Feature",
+        "id": row["identifier"] or row["id"],
+        "geometry": json.loads(row["geometry_json"]),
+        "properties": properties,
+    }
+
+
+def get_heritage_registry_layer():
+    with get_db_connection() as connection:
+        rows = connection.execute(
+            """
+            SELECT *
+            FROM heritage_sites
+            ORDER BY name COLLATE NOCASE
+            """
+        ).fetchall()
+
+    return {
+        "type": "FeatureCollection",
+        "name": "heritage_registry",
+        "features": [row_to_heritage_feature(row) for row in rows],
+    }
+
+
 def get_heritage_sites():
     with get_db_connection() as connection:
         rows = connection.execute(
@@ -80,6 +124,166 @@ def get_heritage_site_by_id(site_id):
         ).fetchone()
 
     return row_to_heritage_site(row) if row else None
+
+
+def normalize_heritage_kind(value):
+    normalized = str(value or "").strip().lower()
+    if normalized == "aboriginal":
+        return "Aboriginal"
+    if normalized == "non-aboriginal":
+        return "Non-Aboriginal"
+    return None
+
+
+def normalize_risk_level(value):
+    normalized = str(value or "").strip().lower()
+    if normalized == "high":
+        return "High"
+    if normalized == "medium":
+        return "Medium"
+    if normalized == "low":
+        return "Low"
+    return None
+
+
+def require_text(data, field_name):
+    value = data.get(field_name)
+    if not isinstance(value, str) or value.strip() == "":
+        raise ValueError(f"{field_name} is required")
+    return value.strip()
+
+
+def require_number(data, field_name, low=None, high=None):
+    value = data.get(field_name)
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be a number")
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{field_name} must be a number") from None
+
+    if low is not None and number < low:
+        raise ValueError(f"{field_name} must be at least {low}")
+    if high is not None and number > high:
+        raise ValueError(f"{field_name} must be at most {high}")
+    return number
+
+
+def create_heritage_site(data):
+    name = require_text(data, "site_name")
+    heritage_type = require_text(data, "heritage_type")
+    fuel_type = require_text(data, "fuel_type")
+    burn_context = require_text(data, "burn_context")
+    submitted_by = require_text(data, "added_by_user_name")
+    latitude = require_number(data, "latitude", -90, 90)
+    longitude = require_number(data, "longitude", -180, 180)
+    slope = require_number(data, "slope", 0, 90)
+    vulnerability_score = require_number(data, "vulnerability_score", 0, 100)
+
+    heritage_kind = normalize_heritage_kind(data.get("heritage_kind"))
+    if heritage_kind is None:
+        raise ValueError("heritage_kind must be Aboriginal or Non-Aboriginal")
+
+    vulnerability_level = normalize_risk_level(data.get("vulnerability_level"))
+    if vulnerability_level is None:
+        raise ValueError("vulnerability_level must be Low, Medium, or High")
+
+    identifier = f"USER-{datetime.now(timezone.utc).strftime('%Y%m%d')}-{uuid.uuid4().hex[:8].upper()}"
+    geometry = {
+        "type": "Point",
+        "coordinates": [longitude, latitude],
+    }
+    properties = {
+        "layer": "Heritage",
+        "id": identifier,
+        "identifier": identifier,
+        "name": name,
+        "heritage_kind": heritage_kind,
+        "place_type": heritage_type,
+        "source": "user",
+        "longitude": longitude,
+        "latitude": latitude,
+        "fuel_class": fuel_type,
+        "slope_degrees": slope,
+        "burn_management_context": burn_context,
+        "vulnerability_score": vulnerability_score,
+        "vulnerability_level": vulnerability_level,
+        "added_by_user_name": submitted_by,
+        "enrichment_status": "User submitted site; environmental enrichment not run.",
+    }
+
+    with get_db_connection() as connection:
+        connection.execute(
+            """
+            INSERT INTO heritage_sites (
+                id,
+                identifier,
+                name,
+                source,
+                data_source,
+                geometry_json,
+                properties_json,
+                latitude,
+                longitude,
+                heritage_type,
+                fuel_class,
+                slope_degrees,
+                vulnerability_score,
+                vulnerability_level
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                identifier,
+                identifier,
+                name,
+                "user",
+                None,
+                json.dumps(geometry, separators=(",", ":")),
+                json.dumps(properties, separators=(",", ":")),
+                latitude,
+                longitude,
+                heritage_type,
+                fuel_type,
+                slope,
+                vulnerability_score,
+                vulnerability_level,
+            ),
+        )
+        row = connection.execute(
+            "SELECT * FROM heritage_sites WHERE id = ?",
+            (identifier,),
+        ).fetchone()
+        connection.commit()
+
+    return row_to_heritage_site(row), row_to_heritage_feature(row)
+
+
+def delete_user_heritage_site(site_id):
+    with get_db_connection() as connection:
+        row = connection.execute(
+            """
+            SELECT id, source
+            FROM heritage_sites
+            WHERE id = ? OR identifier = ?
+            LIMIT 1
+            """,
+            (site_id, site_id),
+        ).fetchone()
+
+        if row is None:
+            return "not_found"
+
+        if str(row["source"] or "").strip().lower() != "user":
+            return "not_user_site"
+
+        connection.execute(
+            "DELETE FROM heritage_sites WHERE id = ?",
+            (row["id"],),
+        )
+        connection.commit()
+
+    return "deleted"
 
 
 def get_geojson_layer(layer_name):

--- a/src/components/AddSiteModal.tsx
+++ b/src/components/AddSiteModal.tsx
@@ -8,6 +8,8 @@ export type AddSiteFormData = {
   slope: string
   fuel_type: string
   burn_context: string
+  vulnerability_score: string
+  vulnerability_level: 'High' | 'Medium' | 'Low' | ''
   longitude: string
   latitude: string
   added_by_user_name: string
@@ -17,10 +19,19 @@ export type AddSiteFormData = {
 type AddSiteModalProps = {
   open: boolean
   onClose: () => void
-  onSubmitted: () => void
+  onSubmitted: (feature: HeritageFeature) => void
   heritageTypeOptions: string[]
   fuelTypeOptions: string[]
   burnContextOptions: string[]
+}
+
+type HeritageFeature = {
+  type: string
+  geometry: {
+    type: string
+    coordinates: unknown
+  } | null
+  properties: Record<string, unknown>
 }
 
 const EMPTY_FORM: AddSiteFormData = {
@@ -30,6 +41,8 @@ const EMPTY_FORM: AddSiteFormData = {
   slope: '',
   fuel_type: '',
   burn_context: '',
+  vulnerability_score: '',
+  vulnerability_level: '',
   longitude: '',
   latitude: '',
   added_by_user_name: '',
@@ -54,6 +67,7 @@ const validate = (data: AddSiteFormData): Errors => {
   if (data.heritage_kind === '') errors.heritage_kind = 'Heritage kind is required.'
   if (isBlank(data.fuel_type)) errors.fuel_type = 'Fuel type is required.'
   if (isBlank(data.burn_context)) errors.burn_context = 'Burn context is required.'
+  if (data.vulnerability_level === '') errors.vulnerability_level = 'Vulnerability level is required.'
   if (isBlank(data.added_by_user_name)) errors.added_by_user_name = 'Your name is required.'
 
   if (!isFiniteNumber(data.slope)) {
@@ -61,6 +75,13 @@ const validate = (data: AddSiteFormData): Errors => {
   } else {
     const slope = Number(data.slope)
     if (slope < 0 || slope > 90) errors.slope = 'Slope must be between 0 and 90 degrees.'
+  }
+
+  if (!isFiniteNumber(data.vulnerability_score)) {
+    errors.vulnerability_score = 'Vulnerability score must be a number.'
+  } else {
+    const score = Number(data.vulnerability_score)
+    if (score < 0 || score > 100) errors.vulnerability_score = 'Vulnerability score must be between 0 and 100.'
   }
 
   if (!isFiniteNumber(data.longitude)) {
@@ -84,6 +105,7 @@ const fieldLabelClass = 'block text-xs font-bold uppercase tracking-wider text-g
 const fieldInputClass =
   'w-full bg-white border border-gray-200 rounded-lg px-3 py-2 text-sm text-gray-700 outline-none focus:border-gray-400'
 const fieldErrorClass = 'mt-1 text-xs font-semibold text-red-600'
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://127.0.0.1:5000'
 
 const AddSiteModal = ({
   open,
@@ -95,12 +117,14 @@ const AddSiteModal = ({
 }: AddSiteModalProps) => {
   const [formData, setFormData] = useState<AddSiteFormData>(EMPTY_FORM)
   const [errors, setErrors] = useState<Errors>({})
+  const [submitError, setSubmitError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
 
   useEffect(() => {
     if (!open) {
       setFormData(EMPTY_FORM)
       setErrors({})
+      setSubmitError(null)
       setSubmitting(false)
     }
   }, [open])
@@ -125,8 +149,9 @@ const AddSiteModal = ({
     handleChange('heritage_photo', file)
   }
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    setSubmitError(null)
     const validationErrors = validate(formData)
     if (Object.keys(validationErrors).length > 0) {
       setErrors(validationErrors)
@@ -134,15 +159,33 @@ const AddSiteModal = ({
     }
 
     setSubmitting(true)
-    // TODO: call backend POST when API ready
-    console.log('[AddSite] form submitted', {
-      ...formData,
-      heritage_photo: formData.heritage_photo
-        ? { name: formData.heritage_photo.name, size: formData.heritage_photo.size }
-        : null,
-    })
-    setSubmitting(false)
-    onSubmitted()
+    try {
+      const response = await fetch(`${API_BASE}/api/heritage`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          ...formData,
+          heritage_photo: undefined,
+          slope: Number(formData.slope),
+          longitude: Number(formData.longitude),
+          latitude: Number(formData.latitude),
+          vulnerability_score: Number(formData.vulnerability_score),
+        }),
+      })
+      const result = await response.json()
+
+      if (!response.ok) {
+        throw new Error(result?.error ?? 'Could not submit heritage site.')
+      }
+
+      onSubmitted(result.feature as HeritageFeature)
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : 'Could not submit heritage site.')
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
@@ -303,6 +346,39 @@ const AddSiteModal = ({
             </div>
           </div>
 
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className={fieldLabelClass} htmlFor="vulnerability_score">Vulnerability score *</label>
+              <input
+                id="vulnerability_score"
+                type="number"
+                step="any"
+                min={0}
+                max={100}
+                value={formData.vulnerability_score}
+                onChange={(e) => handleChange('vulnerability_score', e.target.value)}
+                className={fieldInputClass}
+              />
+              {errors.vulnerability_score && <p className={fieldErrorClass}>{errors.vulnerability_score}</p>}
+            </div>
+
+            <div>
+              <label className={fieldLabelClass} htmlFor="vulnerability_level">Vulnerability level *</label>
+              <select
+                id="vulnerability_level"
+                value={formData.vulnerability_level}
+                onChange={(e) => handleChange('vulnerability_level', e.target.value as AddSiteFormData['vulnerability_level'])}
+                className={fieldInputClass}
+              >
+                <option value="">Select…</option>
+                <option value="High">High</option>
+                <option value="Medium">Medium</option>
+                <option value="Low">Low</option>
+              </select>
+              {errors.vulnerability_level && <p className={fieldErrorClass}>{errors.vulnerability_level}</p>}
+            </div>
+          </div>
+
           <div>
             <label className={fieldLabelClass} htmlFor="added_by_user_name">Submitted by *</label>
             <input
@@ -331,6 +407,12 @@ const AddSiteModal = ({
               </p>
             )}
           </div>
+
+          {submitError && (
+            <div className="bg-red-50 border border-red-100 text-red-700 rounded-lg px-3 py-2 text-sm font-semibold">
+              {submitError}
+            </div>
+          )}
 
           <div className="flex justify-end gap-3 pt-2 border-t border-gray-100">
             <button

--- a/src/pages/HeritagRegistry.tsx
+++ b/src/pages/HeritagRegistry.tsx
@@ -31,7 +31,7 @@ type RegistrySite = {
 }
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://127.0.0.1:5000'
-const HERITAGE_DATA_URL = `${API_BASE}/api/layers/heritage`
+const HERITAGE_DATA_URL = `${API_BASE}/api/heritage-registry`
 
 const HERITAGE_CSV_FIELDS = [
   ['Identifier', 'identifier'],
@@ -196,6 +196,8 @@ const HeritagRegistry = () => {
   const [downloadError, setDownloadError] = useState<string | null>(null)
   const [isAddSiteOpen, setIsAddSiteOpen] = useState(false)
   const [addSiteNotice, setAddSiteNotice] = useState<string | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+  const [deletingSiteId, setDeletingSiteId] = useState<string | null>(null)
 
   useEffect(() => {
     let active = true
@@ -317,6 +319,41 @@ const HeritagRegistry = () => {
     }
   }
 
+  const deleteHeritageSite = async (site: RegistrySite) => {
+    if (!isUserSource(site.source)) return
+    const confirmed = window.confirm(`Delete ${site.name} from the registry?`)
+    if (!confirmed) return
+
+    setDeleteError(null)
+    setAddSiteNotice(null)
+    setDeletingSiteId(site.id)
+
+    try {
+      const response = await fetch(`${API_BASE}/api/heritage/${encodeURIComponent(site.id)}`, {
+        method: 'DELETE',
+      })
+      const result = await response.json()
+
+      if (!response.ok) {
+        throw new Error(result?.error ?? 'Could not delete heritage site.')
+      }
+
+      setHeritageData((current) => ({
+        type: 'FeatureCollection',
+        features: current?.features.filter((feature) => {
+          const properties = feature.properties
+          const featureId = textValue(properties.identifier ?? properties.id, '')
+          return featureId !== site.id
+        }) ?? [],
+      }))
+      setAddSiteNotice('User-submitted site deleted from the registry.')
+    } catch (error) {
+      setDeleteError(error instanceof Error ? error.message : 'Could not delete heritage site.')
+    } finally {
+      setDeletingSiteId(null)
+    }
+  }
+
   return (
     <div className="px-8 py-8 min-h-full" style={{ background: '#F0EDE8' }}>
       <div className="flex justify-between items-center mb-6">
@@ -345,6 +382,12 @@ const HeritagRegistry = () => {
       {loadError && (
         <div className="mb-4 bg-red-50 border border-red-100 text-red-700 rounded-lg px-4 py-3 text-sm font-semibold">
           {loadError}
+        </div>
+      )}
+
+      {deleteError && (
+        <div className="mb-4 bg-red-50 border border-red-100 text-red-700 rounded-lg px-4 py-3 text-sm font-semibold">
+          {deleteError}
         </div>
       )}
 
@@ -505,11 +548,27 @@ const HeritagRegistry = () => {
                     {site.score === null ? 'Unknown' : site.score}
                   </td>
                   <td className="px-4 py-3">
-                    <button className="text-gray-400 hover:text-gray-600 p-1 rounded hover:bg-gray-100">
-                      <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                        <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z"/>
-                      </svg>
-                    </button>
+                    {isUserSource(site.source) ? (
+                      <button
+                        type="button"
+                        onClick={() => deleteHeritageSite(site)}
+                        disabled={deletingSiteId === site.id}
+                        className="text-red-600 hover:text-red-700 px-2 py-1 rounded hover:bg-red-50 text-xs font-bold disabled:opacity-60"
+                      >
+                        {deletingSiteId === site.id ? 'Deleting...' : 'Delete'}
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        disabled
+                        title="Only user-submitted sites can be deleted"
+                        className="text-gray-300 p-1 rounded cursor-not-allowed"
+                      >
+                        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                          <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z"/>
+                        </svg>
+                      </button>
+                    )}
                   </td>
                 </tr>
               ))
@@ -521,9 +580,17 @@ const HeritagRegistry = () => {
       <AddSiteModal
         open={isAddSiteOpen}
         onClose={() => setIsAddSiteOpen(false)}
-        onSubmitted={() => {
+        onSubmitted={(feature) => {
+          setHeritageData((current) => ({
+            type: 'FeatureCollection',
+            features: [...(current?.features ?? []), feature],
+          }))
+          setSearch('')
+          setVulnFilter('All')
+          setHeritageKindFilter('All')
+          setSourceFilter('All')
           setIsAddSiteOpen(false)
-          setAddSiteNotice('Site submitted (pending backend integration).')
+          setAddSiteNotice('Site submitted and added to the registry.')
         }}
         heritageTypeOptions={heritageTypeOptions}
         fuelTypeOptions={fuelTypeOptions}


### PR DESCRIPTION
## Summary
- Add backend API to create user-submitted heritage sites
- Add backend API to delete user-submitted sites only
- Connect Add Site modal to SQLite-backed API
- Show Delete action for user-submitted rows in Heritage Registry

## Verification
- `npm run build`
- `python3 -m py_compile backend/routes/heritage_routes.py backend/services/data_loader.py`
