### PR TITLE
Add frontend testing foundation coverage

### DIFF
--- a/tests/frontend/testing_setup.test.tsx
+++ b/tests/frontend/testing_setup.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+afterEach(() => {
+  cleanup()
+})
+
+function CounterHarness() {
+  const [count, setCount] = useState(0)
+
+  return (
+    <button type="button" onClick={() => setCount((value) => value + 1)}>
+      Count: {count}
+    </button>
+  )
+}
+
+describe('frontend testing foundation', () => {
+  it('provides a browser-like jsdom environment', () => {
+    expect(window).toBeDefined()
+    expect(document).toBeDefined()
+    expect(document.body).toBeInTheDocument()
+    expect(window.location.pathname).toBe('/')
+  })
+
+  it('loads jest-dom matchers from the shared setup file', () => {
+    render(
+      <section>
+        <h2>Testing foundation ready</h2>
+      </section>
+    )
+
+    expect(screen.getByRole('heading', { name: 'Testing foundation ready' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Testing foundation ready' })).toHaveTextContent(
+      'Testing foundation ready'
+    )
+  })
+
+  it('supports basic React rendering and user interaction', async () => {
+    const user = userEvent.setup()
+    render(<CounterHarness />)
+
+    const counterButton = screen.getByRole('button', { name: 'Count: 0' })
+    expect(counterButton).toBeInTheDocument()
+
+    await user.click(counterButton)
+
+    expect(screen.getByRole('button', { name: 'Count: 1' })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
This PR adds a dedicated frontend testing foundation module for the React app.

A new test file was added:

- `tests/frontend/testing_setup.test.tsx`

The new tests verify that the frontend testing environment is working correctly before more feature-level tests are added.

## Included coverage

This PR validates:

- the `jsdom` browser-like test environment
- the shared test setup in `tests/setup.ts`
- `jest-dom` matcher availability
- basic React rendering
- basic user interaction with `userEvent`

Both passed successfully.