### PR TITLE
feat: connect authentication frontend and sqlite database

### DIFF
--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -1,5 +1,9 @@
 from flask import Blueprint, request, jsonify
+from werkzeug.security import generate_password_hash, check_password_hash
+from services.db import get_db_connection
 import re
+import secrets
+
 
 auth_bp = Blueprint("auth", __name__, url_prefix="/api")
 
@@ -9,6 +13,10 @@ def is_valid_email(email):
     return re.match(email_pattern, email) is not None
 
 
+def create_demo_token(user_id):
+    return f"demo-token-{user_id}-{secrets.token_urlsafe(16)}"
+
+
 @auth_bp.route("/register", methods=["POST"])
 def register():
     data = request.get_json()
@@ -16,12 +24,8 @@ def register():
     if data is None:
         return jsonify({"error": "Request body must be valid JSON"}), 400
 
-    username = data.get("username", "").strip()
-    email = data.get("email", "").strip()
+    email = data.get("email", "").strip().lower()
     password = data.get("password", "")
-
-    if not username:
-        return jsonify({"error": "Username is required"}), 400
 
     if not email:
         return jsonify({"error": "Email is required"}), 400
@@ -35,13 +39,46 @@ def register():
     if len(password) < 6:
         return jsonify({"error": "Password must be at least 6 characters long"}), 400
 
-    return jsonify({
-        "message": "Register endpoint is working. Database integration pending.",
-        "user": {
-            "username": username,
-            "email": email
-        }
-    }), 201
+    password_hash = generate_password_hash(password)
+
+    try:
+        conn = get_db_connection()
+
+        existing_user = conn.execute(
+            "SELECT id FROM users WHERE email = ?",
+            (email,),
+        ).fetchone()
+
+        if existing_user:
+            conn.close()
+            return jsonify({"error": "Email is already registered"}), 409
+
+        cursor = conn.execute(
+            """
+            INSERT INTO users (email, password_hash, role)
+            VALUES (?, ?, ?)
+            """,
+            (email, password_hash, "user"),
+        )
+
+        conn.commit()
+        user_id = cursor.lastrowid
+        conn.close()
+
+        return jsonify({
+            "message": "User registered successfully",
+            "user": {
+                "id": user_id,
+                "email": email,
+                "role": "user"
+            }
+        }), 201
+
+    except Exception as e:
+        return jsonify({
+            "error": "Registration failed",
+            "details": str(e)
+        }), 500
 
 
 @auth_bp.route("/login", methods=["POST"])
@@ -51,7 +88,7 @@ def login():
     if data is None:
         return jsonify({"error": "Request body must be valid JSON"}), 400
 
-    email = data.get("email", "").strip()
+    email = data.get("email", "").strip().lower()
     password = data.get("password", "")
 
     if not email:
@@ -63,6 +100,51 @@ def login():
     if not password:
         return jsonify({"error": "Password is required"}), 400
 
-    return jsonify({
-        "message": "Login endpoint is working. Database integration pending."
-    }), 200
+    try:
+        conn = get_db_connection()
+
+        user = conn.execute(
+            """
+            SELECT id, email, password_hash, role
+            FROM users
+            WHERE email = ?
+            """,
+            (email,),
+        ).fetchone()
+
+        if user is None:
+            conn.close()
+            return jsonify({"error": "Invalid email or password"}), 401
+
+        if not user["password_hash"]:
+            conn.close()
+            return jsonify({"error": "This account does not have a password set"}), 401
+
+        if not check_password_hash(user["password_hash"], password):
+            conn.close()
+            return jsonify({"error": "Invalid email or password"}), 401
+
+        conn.execute(
+            "UPDATE users SET last_login_at = CURRENT_TIMESTAMP WHERE id = ?",
+            (user["id"],),
+        )
+        conn.commit()
+        conn.close()
+
+        token = create_demo_token(user["id"])
+
+        return jsonify({
+            "message": "Login successful",
+            "token": token,
+            "user": {
+                "id": user["id"],
+                "email": user["email"],
+                "role": user["role"]
+            }
+        }), 200
+
+    except Exception as e:
+        return jsonify({
+            "error": "Login failed",
+            "details": str(e)
+        }), 500

--- a/backend/services/db.py
+++ b/backend/services/db.py
@@ -1,0 +1,12 @@
+import sqlite3
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+DB_PATH = BACKEND_DIR / "data" / "firewatch.sqlite"
+
+
+def get_db_connection():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import HeritagRegistry from './pages/HeritagRegistry'
 import SiteAssessment from './pages/SiteAssessment'
 import Login from './pages/Login'
 import MitigationGuide from './pages/MitigationGuide'
+import Register from './pages/Register'
 
 const MainLayout = () => {
   return (
@@ -33,6 +34,7 @@ const App = () => {
       <Routes>
         {/* Login page rendered without sidebar layout */}
         <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
         {/* All other routes require an authenticated session and share
             the main layout (sidebar + content). Unauthenticated visits
             are redirected to /login by ProtectedRoute. */}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -26,6 +26,11 @@ export type LoginResponse = {
   user: AuthUser
 }
 
+export type RegisterResponse = {
+  message: string
+  user: AuthUser
+}
+
 /**
  * POST /api/login
  *
@@ -75,6 +80,42 @@ export async function login(email: string, password: string): Promise<LoginRespo
   }
 }
 
+/**
+ * POST /api/register
+ *
+ * Creates a new user account using email and password.
+ */
+export async function register(email: string, password: string): Promise<RegisterResponse> {
+  let response: Response
+  try {
+    response = await fetch(`${API_BASE_URL}/api/register`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({ email, password }),
+    })
+  } catch {
+    throw new Error('Unable to reach the server. Please check your connection and try again.')
+  }
+
+  const body = await safeParseJson(response)
+
+  if (!response.ok) {
+    const message = pickMessage(body) || response.statusText || 'Registration failed.'
+    throw new Error(message)
+  }
+
+  if (!body || !body.user || typeof body.user !== 'object') {
+    throw new Error('Unexpected response from the server.')
+  }
+
+  return {
+    message: typeof body.message === 'string' ? body.message : 'User registered successfully',
+    user: body.user as AuthUser,
+  }
+}
 // Parse the response body as JSON, tolerating empty / non-JSON bodies
 // (which can happen on 204s, 5xx HTML error pages, etc.).
 async function safeParseJson(response: Response): Promise<Record<string, unknown> | null> {

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,38 +1,42 @@
 import { useState, type FormEvent } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { MapContainer, TileLayer, CircleMarker, Tooltip } from 'react-leaflet'
-import { useAuth } from '../contexts/AuthContext'
+import { register as registerRequest } from '../api/auth'
 
-// Approx. centre of Australia (used to frame the continent in the small map)
 const AUSTRALIA_CENTER: [number, number] = [-25, 134]
-// Franklin District (FRK) — approx. Mt Barker / Albany area, Western Australia
 const FRK_LATLNG: [number, number] = [-34.4, 117.8]
 
-const Login = () => {
-  // Controlled form state. Email/password are bound to the inputs;
-  // error holds the message rendered above the submit button; loading
-  // disables the form while a sign-in request is in flight.
+const Register = () => {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
-  const { login } = useAuth()
   const navigate = useNavigate()
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     setError(null)
+    setSuccess(null)
+
+    if (password !== confirmPassword) {
+      setError('Passwords do not match.')
+      return
+    }
+
     setLoading(true)
+
     try {
-      // Delegates to AuthContext, which calls POST /api/login, then
-      // persists the returned token + user to state and localStorage.
-      await login(email, password)
-      // Redirect to the main app on success. `replace` so the login
-      // page is not left in the history stack behind the user.
-      navigate('/', { replace: true })
+      await registerRequest(email, password)
+      setSuccess('Account created successfully. Redirecting to login...')
+
+      setTimeout(() => {
+        navigate('/login', { replace: true })
+      }, 1200)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Sign in failed. Please try again.')
+      setError(err instanceof Error ? err.message : 'Registration failed. Please try again.')
     } finally {
       setLoading(false)
     }
@@ -44,7 +48,6 @@ const Login = () => {
       {/* LEFT — branding */}
       <div className="bg-[#1A1A1A] px-12 py-12 flex flex-col justify-between">
         <div>
-          {/* Brand */}
           <div className="flex items-start gap-3 mb-12">
             <div className="w-12 h-12 rounded-lg bg-[#B03A2E] flex items-center justify-center shadow-sm shadow-black/20 flex-shrink-0">
               <svg viewBox="0 0 64 64" className="w-8 h-8" aria-hidden="true">
@@ -66,21 +69,20 @@ const Login = () => {
             </div>
           </div>
 
-          {/* Hero */}
           <h1 className="text-4xl font-black text-white leading-tight tracking-tight mb-4">
-            Protecting<br />
-            <span className="text-[#8B2020]">Aboriginal Heritage</span><br />
-            from Fire Risk
+            Join the<br />
+            <span className="text-[#8B2020]">Fire Vulnerability</span><br />
+            Assessment Platform
           </h1>
+
           <p className="text-sm text-gray-500 leading-relaxed">
-            A web-based tool for land managers, indigenous rangers,
-            and heritage practitioners in the Franklin District, Western Australia.
+            Create an authorised account to access heritage fire vulnerability tools,
+            site assessment workflows, and risk map features.
           </p>
 
-          {/* Feature bullets */}
           <div className="flex flex-col gap-3 mt-10">
             {[
-              'Heritage Fire Vulnerability Model',
+              'Secure access for authorised project users',
               'Heritage site registry — ACHIS & Inherit',
               'Franklin District (FRK) · Western Australia',
             ].map((item) => (
@@ -91,10 +93,6 @@ const Login = () => {
             ))}
           </div>
 
-          {/* FRK Location Map — display-only mini map showing where the
-              Franklin District sits within Australia. All interactions are
-              disabled so users can read the location at a glance without
-              accidentally panning/zooming. */}
           <div
             className="mt-8 rounded-md overflow-hidden border border-[#2A2A2A]"
             style={{ height: 200 }}
@@ -115,9 +113,6 @@ const Login = () => {
                 url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                 attribution='&copy; OpenStreetMap contributors'
               />
-              {/* Red marker for Franklin District. CircleMarker avoids the
-                  Vite/Leaflet default-icon asset issue and matches the
-                  app's accent colour. */}
               <CircleMarker
                 center={FRK_LATLNG}
                 radius={6}
@@ -137,7 +132,6 @@ const Login = () => {
         </div>
 
         <div>
-          {/* Project Partners */}
           <div className="mb-6">
             <div className="text-[10px] font-bold tracking-widest uppercase text-gray-600 mb-2">
               Project Partners
@@ -154,6 +148,7 @@ const Login = () => {
                   <div className="text-[10px] text-gray-500 leading-tight">Project Partner</div>
                 </div>
               </div>
+
               <div className="flex items-center gap-2 rounded-md border border-[#2A2A2A] bg-[#202020] px-2 py-2">
                 <img
                   src="https://www.uwa.edu.au/_assets/favicon512.png"
@@ -168,11 +163,6 @@ const Login = () => {
             </div>
           </div>
 
-          {/* ICIP / IDaS / Ownership and Conditions Statement.
-              Communicates project ownership, the cultural data principles
-              the tool follows, and the conditions of use. Logos are not
-              repeated here because they already appear in the Project
-              Partners cards above. */}
           <div className="text-[11px] text-gray-500 leading-relaxed mb-4">
             <p>Developed with Wagyl Kaip and The University of Western Australia.</p>
             <p>This tool respects ICIP and IDaS principles.</p>
@@ -185,20 +175,19 @@ const Login = () => {
         </div>
       </div>
 
-      {/* RIGHT — login form */}
+      {/* RIGHT — register form */}
       <div className="flex items-center justify-center px-12 py-12" style={{ background: '#F0EDE8' }}>
         <div className="bg-white rounded-2xl border border-gray-100 p-9 w-full max-w-sm">
-          <h2 className="text-xl font-black text-gray-900 mb-1">Welcome back</h2>
-          <p className="text-sm text-gray-400 mb-7">Sign in to your account to continue</p>
+          <h2 className="text-xl font-black text-gray-900 mb-1">Create account</h2>
+          <p className="text-sm text-gray-400 mb-7">Register to access the assessment platform</p>
 
           <form onSubmit={handleSubmit} noValidate>
-            {/* Email */}
             <div className="mb-4">
-              <label htmlFor="login-email" className="block text-xs font-bold text-gray-500 mb-1.5 tracking-wide">
+              <label htmlFor="register-email" className="block text-xs font-bold text-gray-500 mb-1.5 tracking-wide">
                 Email address
               </label>
               <input
-                id="login-email"
+                id="register-email"
                 type="email"
                 autoComplete="email"
                 required
@@ -210,32 +199,40 @@ const Login = () => {
               />
             </div>
 
-            {/* Password */}
-            <div className="mb-2">
-              <label htmlFor="login-password" className="block text-xs font-bold text-gray-500 mb-1.5 tracking-wide">
+            <div className="mb-4">
+              <label htmlFor="register-password" className="block text-xs font-bold text-gray-500 mb-1.5 tracking-wide">
                 Password
               </label>
               <input
-                id="login-password"
+                id="register-password"
                 type="password"
-                autoComplete="current-password"
+                autoComplete="new-password"
                 required
                 disabled={loading}
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                placeholder="••••••••"
+                placeholder="At least 6 characters"
                 className="w-full px-4 py-3 border border-gray-100 rounded-xl text-sm text-gray-900 bg-gray-50 outline-none focus:border-gray-300 focus:bg-white transition-colors disabled:opacity-60"
               />
             </div>
 
-            {/* Forgot */}
-            <div className="text-right mb-6">
-              <span className="text-xs text-gray-400 cursor-pointer hover:text-gray-600 transition-colors">
-                Forgot password?
-              </span>
+            <div className="mb-5">
+              <label htmlFor="register-confirm-password" className="block text-xs font-bold text-gray-500 mb-1.5 tracking-wide">
+                Confirm password
+              </label>
+              <input
+                id="register-confirm-password"
+                type="password"
+                autoComplete="new-password"
+                required
+                disabled={loading}
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                placeholder="Repeat your password"
+                className="w-full px-4 py-3 border border-gray-100 rounded-xl text-sm text-gray-900 bg-gray-50 outline-none focus:border-gray-300 focus:bg-white transition-colors disabled:opacity-60"
+              />
             </div>
 
-            {/* Inline error message returned from the sign-in attempt. */}
             {error && (
               <div
                 role="alert"
@@ -245,42 +242,40 @@ const Login = () => {
               </div>
             )}
 
-            {/* Sign in btn */}
+            {success && (
+              <div
+                role="status"
+                className="mb-3 px-3 py-2 rounded-lg bg-green-50 border border-green-100 text-xs text-green-700"
+              >
+                {success}
+              </div>
+            )}
+
             <button
               type="submit"
               disabled={loading}
               className="w-full bg-[#1A1A1A] text-white py-3 rounded-xl text-sm font-black hover:bg-gray-800 transition-colors mb-3 disabled:opacity-60 disabled:cursor-not-allowed"
             >
-              {loading ? 'Signing in…' : 'Sign in'}
+              {loading ? 'Creating account…' : 'Create account'}
             </button>
           </form>
 
-          {/* Divider */}
           <div className="flex items-center gap-3 my-4">
             <div className="flex-1 h-px bg-gray-100" />
             <span className="text-xs text-gray-300 font-semibold">or</span>
             <div className="flex-1 h-px bg-gray-100" />
           </div>
 
-          {/* Microsoft btn */}
-          <button className="w-full py-3 rounded-xl text-sm font-bold text-gray-600 flex items-center justify-center gap-2 hover:bg-gray-100 transition-colors" style={{ background: '#F0EDE8' }}>
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-              <rect x="1" y="1" width="6" height="6" rx="1" fill="#4A90D9"/>
-              <rect x="9" y="1" width="6" height="6" rx="1" fill="#4A90D9" opacity=".6"/>
-              <rect x="1" y="9" width="6" height="6" rx="1" fill="#4A90D9" opacity=".6"/>
-              <rect x="9" y="9" width="6" height="6" rx="1" fill="#4A90D9"/>
-            </svg>
-            Sign in with Microsoft
-          </button>
+          <p className="text-center text-xs text-gray-400 leading-relaxed">
+            Already have an account?{' '}
+            <Link to="/login" className="font-bold text-gray-700 hover:text-gray-900">
+              Sign in
+            </Link>
+          </p>
 
-          {/* Footer note */}
           <p className="text-center text-xs text-gray-300 mt-6 leading-relaxed">
-           Do not have an account?{' '}
-           <Link to="/register" className="font-bold text-gray-700 hover:text-gray-900">
-            Create account
-           </Link>
-           <br />
-            Access is restricted to authorised personnel.
+            Registration is intended for authorised project users only.<br />
+            Contact your administrator if you need access approval.
           </p>
         </div>
       </div>
@@ -289,4 +284,4 @@ const Login = () => {
   )
 }
 
-export default Login
+export default Register


### PR DESCRIPTION
Summary

This PR completes the basic authentication flow by connecting the frontend login/register pages with the Flask backend and the existing SQLite users table.

Changes

Backend:
- Connected POST /api/register to the SQLite users table
- Connected POST /api/login to the SQLite users table
- Added password hashing using Werkzeug
- Added password verification during login
- Updated last_login_at after successful login
- Added a shared SQLite database connection helper

Frontend:
- Added Register page
- Added register API client function
- Connected Register page to POST /api/register
- Connected Login page to POST /api/login through AuthContext
- Added "Create account" link on the Login page
- Added /register route outside ProtectedRoute

Testing

- Tested backend POST /api/register successfully
- Tested backend POST /api/login successfully
- Tested frontend registration page
- Tested successful redirect from Register to Login
- Tested successful Login redirect to the main app
- Confirmed ProtectedRoute allows access after login

Notes

For local development, the frontend requires a .env.local file:

VITE_API_BASE_URL=http://127.0.0.1:5000

This file is not included in the PR because it is a local environment configuration.