### PR TITLE
Add backend route + validation tests

### DIFF
--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -20,3 +22,117 @@ def client():
     app_module.app.config.update(TESTING=True)
     with app_module.app.test_client() as test_client:
         yield test_client
+
+
+@pytest.fixture()
+def seeded_backend_db(monkeypatch, tmp_path):
+    """Seed a temporary SQLite DB and route services.data_loader calls to it."""
+
+    import services.data_loader as data_loader
+
+    root_dir = Path(__file__).resolve().parents[2]
+    schema_path = root_dir / "backend" / "database" / "schema.sql"
+    schema_sql = schema_path.read_text(encoding="utf-8")
+
+    db_path = tmp_path / "firewatch.test.sqlite"
+    connection = sqlite3.connect(db_path)
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.executescript(schema_sql)
+
+    connection.execute(
+        "INSERT INTO users (id, email, role) VALUES (?, ?, ?)",
+        (1, "test@firewatch.local", "admin"),
+    )
+
+    site_id = "site-1"
+    geometry = {"type": "Point", "coordinates": [151.0, -33.0]}
+    properties = {"identifier": site_id, "name": "Test Site"}
+    connection.execute(
+        """
+        INSERT INTO heritage_sites (
+            id,
+            identifier,
+            name,
+            source,
+            data_source,
+            geometry_json,
+            properties_json,
+            latitude,
+            longitude,
+            heritage_type,
+            fuel_class,
+            slope_degrees,
+            vulnerability_score,
+            vulnerability_level,
+            assessed_date,
+            created_by
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            site_id,
+            site_id,
+            "Test Heritage Site",
+            "register",
+            "DPLH_099",
+            json.dumps(geometry, separators=(",", ":")),
+            json.dumps(properties, separators=(",", ":")),
+            -33.0,
+            151.0,
+            "Historic",
+            "Forest",
+            10.0,
+            25.0,
+            "Low",
+            "2026-01-01",
+            1,
+        ),
+    )
+
+    connection.execute(
+        """
+        INSERT INTO geojson_features (
+            layer_name,
+            feature_index,
+            feature_id,
+            geometry_json,
+            properties_json,
+            source_path
+        )
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "burn_options",
+            0,
+            "burn-1",
+            json.dumps(
+                {"type": "Point", "coordinates": [151.1, -33.1]},
+                separators=(",", ":"),
+            ),
+            json.dumps({"burnid": "burn-1", "name": "Test Burn"}, separators=(",", ":")),
+            "test://seed",
+        ),
+    )
+
+    processed_metadata = {"version": "test", "generated_at": "2026-01-01T00:00:00Z"}
+    connection.execute(
+        "INSERT INTO app_metadata (key, value_json, source_path) VALUES (?, ?, ?)",
+        ("processed_metadata", json.dumps(processed_metadata, separators=(",", ":")), "test://seed"),
+    )
+
+    connection.commit()
+    connection.close()
+
+    def _patched_get_db_connection(db_path_override=None):
+        patched = sqlite3.connect(db_path)
+        patched.row_factory = sqlite3.Row
+        patched.execute("PRAGMA foreign_keys = ON")
+        return patched
+
+    monkeypatch.setattr(data_loader, "get_db_connection", _patched_get_db_connection)
+
+    return {
+        "db_path": db_path,
+        "site_id": site_id,
+        "processed_metadata": processed_metadata,
+    }

--- a/tests/backend/test_heritage_routes.py
+++ b/tests/backend/test_heritage_routes.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+
+def test_get_sites_returns_count_and_sites(client, seeded_backend_db):
+    response = client.get("/api/sites")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+
+    assert isinstance(payload, dict)
+    assert payload["count"] == 1
+    assert isinstance(payload["sites"], list)
+    assert payload["sites"][0]["id"] == seeded_backend_db["site_id"]
+
+
+def test_get_site_by_id_returns_site(client, seeded_backend_db):
+    response = client.get(f"/api/sites/{seeded_backend_db['site_id']}")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+
+    assert payload["id"] == seeded_backend_db["site_id"]
+    assert payload["name"] == "Test Heritage Site"
+    assert "coordinates" in payload
+    assert payload["coordinates"]["latitude"] == -33.0
+
+
+def test_get_site_by_id_returns_404_for_missing_site(client, seeded_backend_db):
+    response = client.get("/api/sites/does-not-exist")
+
+    assert response.status_code == 404
+    payload = response.get_json()
+    assert payload["error"] == "heritage site not found"
+
+
+def test_processed_metadata_returns_seeded_payload(client, seeded_backend_db):
+    response = client.get("/api/processed-metadata")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+
+    assert payload == seeded_backend_db["processed_metadata"]
+
+
+def test_layers_burn_options_returns_feature_collection(client, seeded_backend_db):
+    response = client.get("/api/layers/burn-options")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+
+    assert payload["type"] == "FeatureCollection"
+    assert payload["name"] == "burn_options"
+    assert isinstance(payload["features"], list)
+    assert len(payload["features"]) == 1

--- a/tests/backend/test_site_assessment_validation.py
+++ b/tests/backend/test_site_assessment_validation.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("body", "content_type"),
+    [
+        ("not-json", "text/plain"),
+        ("", "text/plain"),
+    ],
+)
+def test_site_assessment_rejects_non_json_body(client, body, content_type):
+    response = client.post(
+        "/api/site-assessment",
+        data=body,
+        content_type=content_type,
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["error"] == "Request body must be valid JSON"
+
+
+def test_site_assessment_rejects_non_numeric_field(client):
+    response = client.post(
+        "/api/site-assessment",
+        json={
+            "fuelRisk": "high",
+            "slopeRisk": 0,
+            "heritageTypeRisk": 0,
+            "burnContext": 0,
+        },
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["error"] == "fuelRisk must be a number"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("fuelRisk", -1),
+        ("fuelRisk", 101),
+        ("slopeRisk", -0.1),
+        ("burnContext", 100.0001),
+    ],
+)
+def test_site_assessment_rejects_out_of_range_values(client, field, value):
+    payload = {
+        "fuelRisk": 0,
+        "slopeRisk": 0,
+        "heritageTypeRisk": 0,
+        "burnContext": 0,
+    }
+    payload[field] = value
+
+    response = client.post("/api/site-assessment", json=payload)
+
+    assert response.status_code == 400
+    error_payload = response.get_json()
+    assert error_payload["error"] == f"{field} must be between 0 and 100"
+
+
+def test_site_assessment_accepts_floats(client):
+    response = client.post(
+        "/api/site-assessment",
+        json={
+            "fuelRisk": 12.5,
+            "slopeRisk": 0.0,
+            "heritageTypeRisk": 0.0,
+            "burnContext": 0.0,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert "score" in payload
+    assert "riskLevel" in payload


### PR DESCRIPTION
Summary
Adds hermetic backend tests that don’t depend on a pre-existing local SQLite file.
Expands coverage for heritage routes + GeoJSON layer response shape.
Adds additional request-validation coverage for site assessment inputs.
Changes

Update conftest.py
Add seeded_backend_db fixture: creates a temp SQLite DB from the real schema and monkeypatches services.data_loader.get_db_connection.
Add test_heritage_routes.py
Covers GET /api/sites, GET /api/sites/<id>, GET /api/processed-metadata, GET /api/layers/burn-options.
Add test_site_assessment_validation.py
Covers invalid/non-JSON body, non-numeric fields, out-of-range values, float acceptance for POST /api/site-assessment.
