### PR TITLE
Add frontend E2E coverage with PlayWright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ dist-ssr
 *.local
 *.sqlite
 *.sqlite3
+playwright-report/
+test-results/
 
 # Editor directories and files
 .vscode/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -899,6 +900,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@react-leaflet/core": {
@@ -3844,6 +3861,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "e2e": "playwright test",
+    "e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "chart.js": "^4.5.1",
@@ -21,6 +23,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    headless: true,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'off',
+  },
+  projects: [
+    {
+      name: 'chrome',
+      use: {
+        browserName: 'chromium',
+        channel: 'chrome',
+      },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs/promises'
+import { expect, test } from '@playwright/test'
+
+test.describe('frontend E2E flows', () => {
+  test('renders the login page and accepts user input', async ({ page }) => {
+    await page.goto('/login')
+
+    await expect(page.getByRole('heading', { name: 'Welcome back' })).toBeVisible()
+    await expect(page.getByText('Project Partners')).toBeVisible()
+
+    const emailInput = page.getByPlaceholder('you@dpird.wa.gov.au')
+    const passwordInput = page.getByPlaceholder('••••••••')
+
+    await emailInput.fill('ella.zhang@uwa.edu.au')
+    await passwordInput.fill('secret123')
+
+    await expect(emailInput).toHaveValue('ella.zhang@uwa.edu.au')
+    await expect(passwordInput).toHaveValue('secret123')
+    await expect(page.getByRole('button', { name: 'Sign in', exact: true })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Sign in with Microsoft' })).toBeVisible()
+  })
+
+  test('supports sidebar navigation between assessment, regulation, and mitigation guide pages', async ({
+    page,
+  }) => {
+    await page.goto('/assessment')
+
+    await expect(page.getByText(/Fire Vulnerability\s*Assessment Tool/)).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Site Assessment' })).toBeVisible()
+
+    await page.getByRole('link', { name: 'Fire Risk Regulation' }).click()
+    await expect(page).toHaveURL(/\/regulation$/)
+    await expect(page.getByRole('heading', { name: 'FIRE Risk REGULATION' })).toBeVisible()
+
+    await page.getByRole('link', { name: 'View Mitigation Guide' }).click()
+    await expect(page).toHaveURL(/\/mitigation-guide$/)
+    await expect(page.getByRole('heading', { name: 'Mitigation Guide & Methodology' })).toBeVisible()
+
+    await page.getByRole('link', { name: 'Site Assessment' }).click()
+    await expect(page).toHaveURL(/\/assessment$/)
+    await expect(page.getByRole('heading', { name: 'Site Assessment' })).toBeVisible()
+  })
+
+  test('recalculates the Site Assessment result and exports a CSV', async ({ page }) => {
+    await page.goto('/assessment')
+
+    await expect(page.getByText('High Risk')).toBeVisible()
+
+    await page.locator('select').nth(0).selectOption('Brick / stone / masonry / concrete')
+    await page.locator('select').nth(2).selectOption('Water')
+    await page.locator('input[type="range"]').evaluate((element) => {
+      const input = element as HTMLInputElement
+      input.value = '0'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      input.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+
+    await expect(page.getByText('Low Risk')).toBeVisible()
+    await expect(page.getByText('Maintain routine 6-monthly monitoring schedule')).toBeVisible()
+
+    await page.getByPlaceholder('Enter site name').fill('Franklin Rock Shelter')
+    await page.getByPlaceholder('e.g. FRK-094').fill('FRK-094')
+
+    const downloadPromise = page.waitForEvent('download')
+    await page.getByRole('button', { name: 'Export CSV' }).click()
+    const download = await downloadPromise
+
+    expect(download.suggestedFilename()).toBe('assessment_FRK-094.csv')
+
+    const downloadPath = await download.path()
+    expect(downloadPath).not.toBeNull()
+
+    const csv = await fs.readFile(downloadPath!, 'utf-8')
+    expect(csv).toContain('Site Name,Franklin Rock Shelter')
+    expect(csv).toContain('Site ID,FRK-094')
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { configDefaults, defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
@@ -7,5 +7,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: './tests/setup.ts',
+    exclude: [...configDefaults.exclude, 'tests/e2e/**'],
   },
 })


### PR DESCRIPTION
This PR adds Playwright-based frontend end-to-end (E2E) test coverage for the project.

It introduces a dedicated Playwright configuration and a new E2E test suite for key browser-level user flows.

## Included changes

Added:

- `playwright.config.ts`
- `tests/e2e/frontend.e2e.spec.ts`

Updated:

- `package.json`
- `package-lock.json`
- `vite.config.ts`
- `.gitignore`

## E2E coverage included

This PR adds browser-level tests for the following frontend flows:

- login page rendering and form input interaction
- sidebar navigation between:
  - Site Assessment
  - Fire Risk Regulation
  - Mitigation Guide
- Site Assessment interaction flow, including:
  - recalculating the displayed risk result after input changes
  - exporting a CSV file
  - validating the exported filename and file content
 
Ran successfully:

- `npm test`
- `npm run e2e`

