### PR TITLE
 Add missing backend test coverage for auth and heritage routes 

### DIFF
--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -136,3 +136,18 @@ def seeded_backend_db(monkeypatch, tmp_path):
         "site_id": site_id,
         "processed_metadata": processed_metadata,
     }
+
+
+@pytest.fixture()
+def seeded_backend_db_no_metadata(seeded_backend_db):
+    """Provide a seeded DB without processed metadata for 404 tests."""
+
+    db_path = seeded_backend_db["db_path"]
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            "DELETE FROM app_metadata WHERE key = ?",
+            ("processed_metadata",),
+        )
+        connection.commit()
+
+    return seeded_backend_db

--- a/tests/backend/test_auth_and_assessment.py
+++ b/tests/backend/test_auth_and_assessment.py
@@ -20,6 +20,39 @@ def test_register_accepts_valid_input(client):
     assert payload["user"]["email"] == "test@example.com"
 
 
+def test_login_rejects_missing_email(client):
+    response = client.post(
+        "/api/login",
+        json={"password": "secret12"},
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["error"] == "Email is required"
+
+
+def test_login_rejects_missing_password(client):
+    response = client.post(
+        "/api/login",
+        json={"email": "test@example.com"},
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["error"] == "Password is required"
+
+
+def test_login_accepts_valid_input(client):
+    response = client.post(
+        "/api/login",
+        json={"email": "test@example.com", "password": "secret12"},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert "message" in payload
+
+
 def test_site_assessment_validates_required_fields(client):
     response = client.post("/api/site-assessment", json={"fuelRisk": 50})
 

--- a/tests/backend/test_heritage_routes.py
+++ b/tests/backend/test_heritage_routes.py
@@ -13,6 +13,16 @@ def test_get_sites_returns_count_and_sites(client, seeded_backend_db):
     assert payload["sites"][0]["id"] == seeded_backend_db["site_id"]
 
 
+def test_get_heritage_alias_returns_count_and_sites(client, seeded_backend_db):
+    response = client.get("/api/heritage")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+
+    assert payload["count"] == 1
+    assert payload["sites"][0]["id"] == seeded_backend_db["site_id"]
+
+
 def test_get_site_by_id_returns_site(client, seeded_backend_db):
     response = client.get(f"/api/sites/{seeded_backend_db['site_id']}")
 
@@ -23,6 +33,14 @@ def test_get_site_by_id_returns_site(client, seeded_backend_db):
     assert payload["name"] == "Test Heritage Site"
     assert "coordinates" in payload
     assert payload["coordinates"]["latitude"] == -33.0
+
+
+def test_get_heritage_alias_by_id_returns_site(client, seeded_backend_db):
+    response = client.get(f"/api/heritage/{seeded_backend_db['site_id']}")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["id"] == seeded_backend_db["site_id"]
 
 
 def test_get_site_by_id_returns_404_for_missing_site(client, seeded_backend_db):
@@ -40,6 +58,14 @@ def test_processed_metadata_returns_seeded_payload(client, seeded_backend_db):
     payload = response.get_json()
 
     assert payload == seeded_backend_db["processed_metadata"]
+
+
+def test_processed_metadata_returns_404_when_missing(client, seeded_backend_db_no_metadata):
+    response = client.get("/api/processed-metadata")
+
+    assert response.status_code == 404
+    payload = response.get_json()
+    assert payload["error"] == "processed metadata not found"
 
 
 def test_layers_burn_options_returns_feature_collection(client, seeded_backend_db):


### PR DESCRIPTION
Summary

Adds necessary backend tests to cover missing API paths and error cases.
Improves auth coverage with login validation tests.
Confirms 404 path for missing processed metadata.
Changes

[conftest.py]: add [seeded_backend_db_no_metadata] fixture.
[test_heritage_routes.py]: add [/api/heritage] alias tests + [processed-metadata] 404 coverage.
[test_auth_and_assessment.py]: add login error + success tests.