### PR TITLE
feat: add Local Contacts page and refine Fire Risk Regulation buffer zones

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import HeritagRegistry from './pages/HeritagRegistry'
 import SiteAssessment from './pages/SiteAssessment'
 import Login from './pages/Login'
 import MitigationGuide from './pages/MitigationGuide'
+import LocalContacts from './pages/LocalContacts'
 
 const MainLayout = () => {
   return (
@@ -21,6 +22,7 @@ const MainLayout = () => {
           <Route path="/mitigation-guide" element={<MitigationGuide />} />
           <Route path="/registry" element={<HeritagRegistry />} />
           <Route path="/assessment" element={<SiteAssessment />} />
+          <Route path="/contacts" element={<LocalContacts />} />
         </Routes>
       </main>
     </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -36,6 +36,9 @@ const navItems = [
     { to: '/registry', label: 'Heritage Registry' },
     { to: '/assessment', label: 'Site Assessment' },
   ]},
+  { section: 'About', links: [
+    { to: '/contacts', label: 'Local Contacts' },
+  ]},
 ]
 
 const Sidebar = () => {

--- a/src/pages/FireRegulation.tsx
+++ b/src/pages/FireRegulation.tsx
@@ -5,13 +5,18 @@ const FireRegulation = () => {
       <div className="flex flex-col items-center px-12 py-10 h-full overflow-y-auto" style={{ background: '#F0EDE8' }}>
   
         {/* Title */}
-        <h1 className="text-3xl font-black uppercase tracking-wide mb-12">
+        <h1 className="text-3xl font-black uppercase tracking-wide mb-2">
           FIRE Risk REGULATION
         </h1>
-  
+
+        {/* Subtitle */}
+        <p className="text-base font-medium text-gray-700 italic mb-10 text-center">
+          Risk increases sharply within 100m of burnable vegetation
+        </p>
+
         {/* Buffer Diagram */}
         <div className="flex items-stretch w-full max-w-4xl mb-10 rounded-2xl overflow-hidden min-h-[320px]">
-  
+
           {/* Vegetation Panel */}
           <div className="flex-1 flex flex-col items-center justify-center py-10"
             style={{ background: 'linear-gradient(135deg, #d4edda, #a8d5b5)' }}>
@@ -23,17 +28,27 @@ const FireRegulation = () => {
             </svg>
             <p className="text-lg font-bold mt-4 text-gray-800">Vegetation</p>
           </div>
-  
-          {/* Buffer Bar */}
-          <div className="w-16 bg-[#8B2020] flex items-center justify-center flex-shrink-0">
+
+          {/* Inner High-Risk Band — 100m */}
+          <div className="w-12 bg-[#8B2020] flex items-center justify-center flex-shrink-0">
             <p
-              className="text-white text-sm font-black tracking-widest"
+              className="text-white text-xs font-black tracking-widest whitespace-nowrap"
+              style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
+            >
+              100m Great Risk
+            </p>
+          </div>
+
+          {/* Outer Buffer Band — 1000m */}
+          <div className="w-20 bg-[#D97706] flex items-center justify-center flex-shrink-0">
+            <p
+              className="text-white text-sm font-black tracking-widest whitespace-nowrap"
               style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
             >
               1000m Buffer
             </p>
           </div>
-  
+
           {/* Heritage Panel */}
           <div className="flex-1 flex flex-col items-center justify-center py-10 bg-gray-300 rounded-r-2xl">
             {/* Building SVG */}
@@ -54,8 +69,12 @@ const FireRegulation = () => {
         {/* Rule Text */}
         <div className="text-center mb-10">
           <p className="text-lg font-bold text-gray-900">
-            Heritage within 1000m of burnable vegetation are considered{' '}
-            <span className="text-[#8B2020]">AT RISK.</span>
+            Heritage within <span className="text-[#8B2020]">100m</span> of burnable vegetation are at{' '}
+            <span className="text-[#8B2020]">GREAT RISK.</span>
+          </p>
+          <p className="text-lg font-bold text-gray-900 mt-2">
+            Heritage within <span className="text-[#D97706]">1000m</span> falls within the{' '}
+            <span className="text-[#D97706]">planning buffer zone</span> — review and prepare.
           </p>
           <p className="text-lg font-bold text-gray-900 mt-2">
             Consult Planning guide for mitigation strategies.

--- a/src/pages/FireRegulation.tsx
+++ b/src/pages/FireRegulation.tsx
@@ -89,9 +89,12 @@ const FireRegulation = () => {
           >
             View Mitigation Guide
           </Link>
-          <button className="flex-1 py-5 rounded-xl bg-[#8B2020] text-white text-lg font-bold hover:bg-[#6B1010] transition-colors">
+          <Link
+            to="/contacts"
+            className="flex-1 py-5 rounded-xl bg-[#8B2020] text-white text-lg font-bold hover:bg-[#6B1010] transition-colors text-center"
+          >
             Contact Local Planner
-          </button>
+          </Link>
         </div>
   
       </div>

--- a/src/pages/LocalContacts.tsx
+++ b/src/pages/LocalContacts.tsx
@@ -1,0 +1,139 @@
+import { Link } from 'react-router-dom'
+
+// UWA-based researchers leading the project. Data sourced from
+// issue #82 (Local Contacts).
+const contacts = [
+  {
+    name: 'Sean Winter',
+    title: 'Dr, BA PhD W.Aust.',
+    projectRole: 'Client / Project Owner',
+    academicRole: 'Adjunct Lecturer, School of Social Sciences, Archaeology',
+    email: 'sean.winter@uwa.edu.au',
+    extraAffiliation: {
+      label: 'Also affiliated with',
+      orgName: 'Wagyl Kaip Southern Noongar (WKSN) Aboriginal Corporation',
+      logoUrl:
+        'https://images.squarespace-cdn.com/content/v1/61f8e2c584741255f5ca8798/290d1715-85eb-4c72-a7e6-9c59ca2501ca/WKSNLogo.png',
+      logoAlt: 'Wagyl Kaip Southern Noongar logo',
+    },
+  },
+  {
+    name: 'Sven Ouzman',
+    title: 'PhD Berkeley, SFHEA',
+    projectRole: 'Client / Project Owner',
+    academicRole:
+      'Associate Professor, School of Social Sciences; School of Social Sciences, Archaeology; Centre for Rock Art Research and Management',
+    email: 'sven.ouzman@uwa.edu.au',
+    extraAffiliation: null,
+  },
+] as const
+
+const LocalContacts = () => {
+  return (
+    <div
+      className="flex flex-col items-center px-12 py-10 h-full overflow-y-auto"
+      style={{ background: '#F0EDE8' }}
+    >
+      {/* Title */}
+      <h1 className="text-3xl font-black uppercase tracking-wide mb-2">
+        LOCAL CONTACTS
+      </h1>
+
+      {/* Subtitle */}
+      <p className="text-base font-medium text-gray-700 italic mb-10 text-center">
+        UWA-based researchers leading this project
+      </p>
+
+      {/* Contact Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-5xl mb-10">
+        {contacts.map((person) => (
+          <article
+            key={person.email}
+            className="relative bg-white rounded-2xl shadow-sm overflow-hidden flex flex-col"
+          >
+            {/* Header colour bar */}
+            <div className="h-3 w-full bg-[#8B2020]" />
+
+            {/* Project Role badge — pinned top-right of card body */}
+            <span
+              className="absolute top-6 right-5 text-[10px] font-black uppercase tracking-widest bg-[#8B2020] text-white px-2.5 py-1 rounded-full"
+            >
+              Project Owner
+            </span>
+
+            <div className="p-7 flex-1 flex flex-col">
+              {/* Name */}
+              <h2 className="text-2xl font-black text-gray-900 pr-32">
+                {person.name}
+              </h2>
+              {/* Title / qualifications */}
+              <p className="text-sm text-gray-500 mt-1 mb-5">{person.title}</p>
+
+              {/* Project Role */}
+              <div className="mb-4">
+                <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
+                  Project Role
+                </div>
+                <p className="text-sm font-bold text-[#8B2020]">
+                  {person.projectRole}
+                </p>
+              </div>
+
+              {/* Academic Role */}
+              <div className="mb-4">
+                <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
+                  Academic Role
+                </div>
+                <p className="text-sm text-gray-800 leading-relaxed">
+                  {person.academicRole}
+                </p>
+              </div>
+
+              {/* Email */}
+              <div className="mb-4">
+                <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
+                  Email
+                </div>
+                <a
+                  href={`mailto:${person.email}`}
+                  className="text-sm font-medium text-[#1565C0] hover:text-[#0D47A1] hover:underline break-all"
+                >
+                  {person.email}
+                </a>
+              </div>
+
+              {/* Extra affiliation (e.g. WKSN for Sean) */}
+              {person.extraAffiliation && (
+                <div className="mt-auto pt-5 border-t border-gray-200">
+                  <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-2">
+                    {person.extraAffiliation.label}
+                  </div>
+                  <div className="flex items-center gap-3 rounded-lg bg-[#F0EDE8] px-3 py-2.5">
+                    <img
+                      src={person.extraAffiliation.logoUrl}
+                      alt={person.extraAffiliation.logoAlt}
+                      className="w-10 h-10 rounded object-contain bg-white p-1 flex-shrink-0"
+                    />
+                    <p className="text-sm font-semibold text-gray-900 leading-tight">
+                      {person.extraAffiliation.orgName}
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </article>
+        ))}
+      </div>
+
+      {/* Back link */}
+      <Link
+        to="/regulation"
+        className="text-sm font-bold text-gray-700 hover:text-[#8B2020] transition-colors"
+      >
+        ← Back to Fire Risk Regulation
+      </Link>
+    </div>
+  )
+}
+
+export default LocalContacts


### PR DESCRIPTION
## Description

This PR delivers issue #82 (Local Contacts page) and incorporates Sven Ouzman's review feedback on the Fire Risk Regulation page, since both pieces of work emerged from the same client review session and reference one another in the UI.

## What's changed

**1. Fire Risk Regulation page — clarify the actual risk distance** (`cb0cbd4`)

Sven Ouzman flagged that while a 1000m buffer is fine as a planning concept, the *great* risk to heritage actually occurs within 100m of burnable vegetation, not 1000m. The page previously implied a single uniform "at risk" zone.

- Added a subtitle below the H1: *Risk increases sharply within 100m of burnable vegetation*
- Split the buffer diagram into two stacked bands: an inner narrow `100m Great Risk` band in deep red (#8B2020) directly adjacent to vegetation, and an outer wider `1000m Buffer` band in orange (#D97706)
- Rewrote the rule text to explicitly separate the two zones — 100m as GREAT RISK, 1000m as planning buffer for review and preparation

**2. New Local Contacts page** (`6e5bba1`, `c98156a`, `f17c987`, `43b7f29`)

Added a new `/contacts` page surfacing the two UWA-based researchers leading the project, addressing all four acceptance criteria on #82.

- `LocalContacts` page with two responsive cards (1 column on mobile, 2 columns from `md`) for Sean Winter and Sven Ouzman, each showing project role, academic role, and a `mailto:` email link
- Sean Winter's affiliation with the Wagyl Kaip Southern Noongar (WKSN) Aboriginal Corporation is prominently surfaced via a dedicated logo block, in line with the issue's note about considering whether the WKSN affiliation should be displayed alongside the UWA role
- A "Project Owner" badge pinned to the top-right of each card visually echoes the existing red CTA buttons elsewhere in the app
- Registered `/contacts` route inside the authenticated `MainLayout` in `App.tsx`
- Added a new `About` section to the sidebar containing a `Local Contacts` link, so the page is reachable from anywhere
- Wired the previously inert "Contact Local Planner" button on the Fire Risk Regulation page to navigate to `/contacts`, completing the user journey from risk awareness → outreach

## Files touched

- `src/pages/FireRegulation.tsx` — diagram + rule text + button link
- `src/pages/LocalContacts.tsx` (new)
- `src/App.tsx` — register `/contacts`
- `src/components/layout/Sidebar.tsx` — add `About → Local Contacts`

## Acceptance criteria (issue #82)

- [x] New "Local Contacts" page created
- [x] Both contacts displayed with name, role, and email
- [x] Sean Winter's WKSN Aboriginal Corporation affiliation is included
- [x] Page is accessible from the site navigation

## How to test

1. Pull the branch, run `npm run dev`
2. Sign in, navigate to `Fire Risk Regulation` from the sidebar — confirm the 100m / 1000m two-band diagram and updated rule text render correctly
3. Click `Contact Local Planner` → should land on the new `/contacts` page
4. From any page, use the sidebar `About → Local Contacts` entry — should also land on `/contacts`
5. Confirm both contact cards render, the `Project Owner` badge sits at top-right, the WKSN logo block shows only on Sean Winter's card, and the email links open the system mail client
6. Click `← Back to Fire Risk Regulation` — should return to `/regulation`
7. Resize to mobile width — cards should stack to a single column

## Related

Closes #82
Addresses Sven Ouzman's review comment on the Fire Risk Regulation page