### PR TITLE
feat: restrict registration to admin secret

### DIFF
--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -3,6 +3,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from services.db import get_db_connection
 import re
 import secrets
+import os
 
 
 auth_bp = Blueprint("auth", __name__, url_prefix="/api")
@@ -12,6 +13,18 @@ def is_valid_email(email):
     email_pattern = r"^[\w\.-]+@[\w\.-]+\.\w+$"
     return re.match(email_pattern, email) is not None
 
+def validate_admin_secret():
+    expected_secret = os.environ.get("ADMIN_REGISTER_SECRET")
+    provided_secret = request.headers.get("X-Admin-Secret", "")
+
+    if not expected_secret:
+        return jsonify({"error": "Admin registration secret is not configured"}), 500
+
+    if provided_secret != expected_secret:
+        return jsonify({"error": "Admin registration secret is invalid or missing"}), 403
+
+    return None
+
 
 def create_demo_token(user_id):
     return f"demo-token-{user_id}-{secrets.token_urlsafe(16)}"
@@ -19,6 +32,10 @@ def create_demo_token(user_id):
 
 @auth_bp.route("/register", methods=["POST"])
 def register():
+    secret_error = validate_admin_secret()
+    if secret_error:
+        return secret_error
+
     data = request.get_json()
 
     if data is None:
@@ -26,6 +43,7 @@ def register():
 
     email = data.get("email", "").strip().lower()
     password = data.get("password", "")
+    role = str(data.get("role", "user")).strip().lower()
 
     if not email:
         return jsonify({"error": "Email is required"}), 400
@@ -38,6 +56,9 @@ def register():
 
     if len(password) < 6:
         return jsonify({"error": "Password must be at least 6 characters long"}), 400
+    
+    if role not in ("admin", "user", "viewer"):
+        return jsonify({"error": "Role must be admin, user, or viewer"}), 400
 
     password_hash = generate_password_hash(password)
 
@@ -58,7 +79,7 @@ def register():
             INSERT INTO users (email, password_hash, role)
             VALUES (?, ?, ?)
             """,
-            (email, password_hash, "user"),
+            (email, password_hash, role),
         )
 
         conn.commit()
@@ -70,7 +91,7 @@ def register():
             "user": {
                 "id": user_id,
                 "email": email,
-                "role": "user"
+                "role": role
             }
         }), 201
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,6 @@ import HeritagRegistry from './pages/HeritagRegistry'
 import SiteAssessment from './pages/SiteAssessment'
 import Login from './pages/Login'
 import MitigationGuide from './pages/MitigationGuide'
-import Register from './pages/Register'
 
 const MainLayout = () => {
   return (
@@ -34,7 +33,6 @@ const App = () => {
       <Routes>
         {/* Login page rendered without sidebar layout */}
         <Route path="/login" element={<Login />} />
-        <Route path="/register" element={<Register />} />
         {/* All other routes require an authenticated session and share
             the main layout (sidebar + content). Unauthenticated visits
             are redirected to /login by ProtectedRoute. */}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -228,10 +228,10 @@ const Login = () => {
               />
             </div>
 
-            {/* Forgot */}
+            {/* Password help */}
             <div className="text-right mb-6">
-              <span className="text-xs text-gray-400 cursor-pointer hover:text-gray-600 transition-colors">
-                Forgot password?
+              <span className="text-xs text-gray-400">
+                Contact administrator to reset password
               </span>
             </div>
 
@@ -275,12 +275,8 @@ const Login = () => {
 
           {/* Footer note */}
           <p className="text-center text-xs text-gray-300 mt-6 leading-relaxed">
-           Do not have an account?{' '}
-           <Link to="/register" className="font-bold text-gray-700 hover:text-gray-900">
-            Create account
-           </Link>
-           <br />
-            Access is restricted to authorised personnel.
+            Access is restricted to authorised internal personnel.<br />
+            Accounts are created by the project administrator.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Summary

This update changes the authentication flow to better match the client requirement that the system should only be used by internal personnel.

Public self-registration is disabled from the frontend. Users can only access the Login page. New accounts must be created through the backend registration API with a valid X-Admin-Secret header.

Changes

- Removed the public Create account link from the Login page
- Removed public frontend access to /register
- Protected POST /api/register using X-Admin-Secret
- Added role support for backend-created users: admin, user, viewer
- Kept frontend login working with backend-created accounts

How account creation works

Accounts are created from the backend using:

curl -X POST http://127.0.0.1:5000/api/register \
-H "Content-Type: application/json" \
-H "X-Admin-Secret: firewatch-internal-demo" \
-d '{"email":"frontendtest@example.com","password":"123456","role":"user"}'

After the account is created, the user logs in from:

http://localhost:5173/login

Testing

- Confirmed Login page no longer shows public registration link
- Confirmed POST /api/register without X-Admin-Secret returns 403
- Confirmed POST /api/register with valid X-Admin-Secret creates an account
- Confirmed backend-created account can log in from the frontend
- Confirmed successful login redirects to the main app

Notes

For local development, the backend must be started with:

export ADMIN_REGISTER_SECRET="firewatch-internal-demo"

The admin secret is not stored in frontend code and should not be committed to GitHub.