### PR TITLE
Add how-to-use instructions to Risk Map

### DIFF
--- a/src/pages/RiskMap.css
+++ b/src/pages/RiskMap.css
@@ -89,6 +89,33 @@
   padding: 14px;
 }
 
+.firewatch-help {
+  gap: 12px;
+}
+
+.firewatch-help__list {
+  display: grid;
+  gap: 10px;
+}
+
+.firewatch-help__item {
+  display: grid;
+  gap: 3px;
+  padding-left: 10px;
+  border-left: 3px solid #297a8c;
+}
+
+.firewatch-help__item strong {
+  color: #202124;
+  font-size: 13px;
+}
+
+.firewatch-help__item span {
+  color: #62676c;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 .firewatch-risk-page h2 {
   margin-bottom: 0;
   font-size: 16px;

--- a/src/pages/RiskMap.tsx
+++ b/src/pages/RiskMap.tsx
@@ -697,6 +697,37 @@ function RiskMap() {
           </div>
         </section>
 
+        <section className="firewatch-card firewatch-help" aria-label="How to use this map">
+          <h2>How to use this map?</h2>
+
+          <div className="firewatch-help__list">
+            <div className="firewatch-help__item">
+              <strong>Move around</strong>
+              <span>Drag the map to pan across the Franklin District study area.</span>
+            </div>
+
+            <div className="firewatch-help__item">
+              <strong>Zoom in and out</strong>
+              <span>Use the + and - buttons, mouse wheel, or touchpad to inspect areas in more detail.</span>
+            </div>
+
+            <div className="firewatch-help__item">
+              <strong>Turn layers on or off</strong>
+              <span>Use Map Layers to show fire vulnerability, heritage places, fuel type, slope, granite influence, or burn options.</span>
+            </div>
+
+            <div className="firewatch-help__item">
+              <strong>Filter heritage places</strong>
+              <span>Use the risk and heritage type filters to focus on specific groups of heritage sites.</span>
+            </div>
+
+            <div className="firewatch-help__item">
+              <strong>View site details</strong>
+              <span>Click a heritage marker, burn area, or granite area to update the details panel below.</span>
+            </div>
+          </div>
+        </section>
+        
         <section className="firewatch-card" aria-label="Layer colour key">
           <h2>Layer Key</h2>
 


### PR DESCRIPTION
## Summary
This PR adds a user-facing "How to use this map?" help panel to the Risk Map page.

## Changes
- Added a help section under the Base Map controls.
- Explained how users can pan, zoom, toggle layers, apply filters, and click map features.
- Added simple CSS styling so the instructions fit the existing Risk Map side panel design.

## Testing
- Ran `npm run build`.
- Checked that the Risk Map page still loads correctly.
- Confirmed the help instructions are visible in the left-side control panel.