### PR TITLE
Improve Risk Map layer label wording

### DIFF
--- a/src/pages/RiskMap.tsx
+++ b/src/pages/RiskMap.tsx
@@ -652,15 +652,14 @@ function RiskMap() {
         <section className="firewatch-card" aria-label="Map layers">
           <h2>Map Layers</h2>
           {(
-            [
-              ['fire', 'Fire vulnerability'],
-              ['heritage', 'Heritage places'],
-              ['burn', 'Burn options'],
-              ['granite', 'Granite influence'],
-              ['fuel', 'Fuel type'],
-              ['slope', 'Slope'],
-            ] as Array<[LayerName, string]>
-          ).map(([layerName, label]) => (
+[
+  ['fire', 'Fire vulnerability overlay'],
+  ['heritage', 'Heritage place markers'],
+  ['burn', 'Prescribed burn areas'],
+  ['granite', 'Granite influence area'],
+  ['fuel', 'Fuel type overlay'],
+  ['slope', 'Slope overlay'],
+] as Array<[LayerName, string]>          ).map(([layerName, label]) => (
             <label key={layerName} className="firewatch-toggle-row">
               <input
                 type="checkbox"


### PR DESCRIPTION
## Summary
This PR improves the wording of the Risk Map layer controls.

## Changes
- Renamed selected layer labels to make their purpose clearer.
- Changed burn layer wording to "Prescribed burn areas".
- Clarified which layers are overlays and which layer uses heritage place markers.

## Testing
- Ran `npm run build`.
- Checked that the Risk Map layer controls still render correctly.

Refs #86