### PR TITLE
Add introduction text to Risk Map Layer Key

### DIFF
--- a/src/pages/RiskMap.tsx
+++ b/src/pages/RiskMap.tsx
@@ -697,9 +697,12 @@ function RiskMap() {
         </section>
 
         <section className="firewatch-card" aria-label="Layer colour key">
-          <h2>Layer Key</h2>
+  <h2>Layer Key</h2>
+  <p className="firewatch-card-helper">
+    Use this key to interpret the colours and symbols shown on the map.
+  </p>
 
-          <div className="firewatch-key-group">
+  <div className="firewatch-key-group">
             <h3>Fire Vulnerability</h3>
             <div>
               <span className="firewatch-key-box firewatch-key-box--high" />

--- a/src/pages/RiskMap.tsx
+++ b/src/pages/RiskMap.tsx
@@ -652,15 +652,14 @@ function RiskMap() {
         <section className="firewatch-card" aria-label="Map layers">
           <h2>Map Layers</h2>
           {(
-            [
-              ['fire', 'Fire vulnerability'],
-              ['heritage', 'Heritage places'],
-              ['burn', 'Burn options'],
-              ['granite', 'Granite influence'],
-              ['fuel', 'Fuel type'],
-              ['slope', 'Slope'],
-            ] as Array<[LayerName, string]>
-          ).map(([layerName, label]) => (
+[
+  ['fire', 'Fire vulnerability overlay'],
+  ['heritage', 'Heritage place markers'],
+  ['burn', 'Prescribed burn areas'],
+  ['granite', 'Granite influence area'],
+  ['fuel', 'Fuel type overlay'],
+  ['slope', 'Slope overlay'],
+] as Array<[LayerName, string]>          ).map(([layerName, label]) => (
             <label key={layerName} className="firewatch-toggle-row">
               <input
                 type="checkbox"


### PR DESCRIPTION
## Summary
This PR adds a short introduction to the Risk Map Layer Key.

## Changes
- Added one sentence explaining the purpose of the Layer Key.
- Kept all existing colour categories and layer meanings unchanged.

## Testing
- Ran `npm run build`.
- Checked that the Layer Key still displays correctly in the side panel.

Refs #87