### PR TITLE
Improve Risk Map Layer Key spacing

### DIFF
--- a/src/pages/RiskMap.css
+++ b/src/pages/RiskMap.css
@@ -133,8 +133,8 @@
 
 .firewatch-key-group {
   display: grid;
-  gap: 6px;
-  padding-top: 10px;
+  gap: 8px;
+  padding-top: 12px;
   border-top: 1px solid #ecece7;
 }
 
@@ -144,7 +144,7 @@
 }
 
 .firewatch-key-group h3 {
-  margin: 0;
+  margin: 0 0 2px;
   color: #202124;
   font-size: 13px;
 }
@@ -152,10 +152,10 @@
 .firewatch-key-group div {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 9px;
   color: #62676c;
   font-size: 12px;
-  line-height: 1.3;
+  line-height: 1.35;
 }
 
 .firewatch-key-box,


### PR DESCRIPTION
## Summary
This PR improves the visual spacing of the Risk Map Layer Key.

## Changes
- Increased spacing between Layer Key items.
- Added slightly clearer spacing under each Layer Key heading.
- Preserved all existing colour meanings and labels.

## Testing
- Ran `npm run build`.
- Checked that the Layer Key remains readable in the side panel.

Closes #87