### PR TITLE
Improve Risk Map details panel guidance

### DIFF
--- a/src/pages/RiskMap.css
+++ b/src/pages/RiskMap.css
@@ -292,6 +292,29 @@
   gap: 10px;
 }
 
+.firewatch-details__heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.firewatch-details__heading h2 {
+  margin: 0;
+}
+
+.firewatch-details__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: #e7f2f4;
+  color: #297a8c;
+  font-size: 12px;
+  font-weight: 800;
+}
+
 .firewatch-metric-list {
   display: grid;
   gap: 10px;

--- a/src/pages/RiskMap.tsx
+++ b/src/pages/RiskMap.tsx
@@ -114,9 +114,9 @@ const defaultLayerVisibility: ToggleState = {
 }
 
 const defaultDetails: DetailState = {
-  title: 'Select a heritage place',
+  title: 'Select a map feature',
   intro:
-    'Drag to pan, scroll to zoom, and click a heritage place, burn option, or geology area to inspect source attributes.',
+    'Drag or zoom the map to explore the study area. Click a heritage place, burn option, or geology area to view its details here.',
   metrics: [],
 }
 

--- a/src/pages/RiskMap.tsx
+++ b/src/pages/RiskMap.tsx
@@ -853,11 +853,13 @@ function RiskMap() {
           </div>
         </section>
 
-        <section className="firewatch-card firewatch-details" aria-live="polite">
-          <h2>{details.title}</h2>
-          <p className="firewatch-details__intro">{details.intro}</p>
-          <dl className="firewatch-metric-list">
-            {details.metrics.map((metric) => (
+<section className="firewatch-card firewatch-details" aria-live="polite">
+  <div className="firewatch-details__heading">
+    <span className="firewatch-details__icon" aria-hidden="true">i</span>
+    <h2>{details.title}</h2>
+  </div>
+  <p className="firewatch-details__intro">{details.intro}</p>
+  <dl className="firewatch-metric-list">            {details.metrics.map((metric) => (
               <div key={metric.label} className="firewatch-metric">
                 <dt>{metric.label}</dt>
                 <dd>{metric.value}</dd>


### PR DESCRIPTION
## Summary
This PR improves the default guidance shown in the Risk Map details panel.

## Changes
- Updated the default details panel title from "Select a heritage place" to "Select a map feature".
- Reworded the default instruction text to make the panel easier to understand.
- Added a small visual cue beside the details panel heading.
- Kept all map interaction logic and data processing unchanged.

## Testing
- Ran `npm run build`.
- Checked that the details panel still renders correctly before any map feature is selected.

Closes #98 