### PR TITLE
Improve Risk Map score method presentation

### DIFF
--- a/src/pages/RiskMap.css
+++ b/src/pages/RiskMap.css
@@ -444,3 +444,24 @@
   font-size: 0.78rem;
   line-height: 1.35;
 }
+
+.firewatch-method__formula {
+  display: grid;
+  gap: 4px;
+}
+
+.firewatch-method__formula strong {
+  color: #202124;
+  font-size: 14px;
+}
+
+.firewatch-method__formula span {
+  color: #4f555b;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.firewatch-method__intro,
+.firewatch-method__note {
+  margin: 0;
+}

--- a/src/pages/RiskMap.css
+++ b/src/pages/RiskMap.css
@@ -49,6 +49,7 @@
 
 .firewatch-brand__lede,
 .firewatch-details__intro,
+.firewatch-method__intro,
 .firewatch-method__note {
   color: #62676c;
   line-height: 1.45;

--- a/src/pages/RiskMap.css
+++ b/src/pages/RiskMap.css
@@ -292,6 +292,29 @@
   gap: 10px;
 }
 
+.firewatch-details__heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.firewatch-details__heading h2 {
+  margin: 0;
+}
+
+.firewatch-details__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: #e7f2f4;
+  color: #297a8c;
+  font-size: 12px;
+  font-weight: 800;
+}
+
 .firewatch-metric-list {
   display: grid;
   gap: 10px;

--- a/src/pages/RiskMap.tsx
+++ b/src/pages/RiskMap.tsx
@@ -873,15 +873,21 @@ function RiskMap() {
   <p className="firewatch-method__intro">
     These weightings explain how vulnerability scores are calculated for heritage places and surrounding areas.
   </p>
-  <p>
-    <strong>Heritage score =</strong> fuel 45% + slope 25% + heritage type/material 25% + burn context 5%.
-  </p>          <p>
-            <strong>Area score =</strong> fuel 55% + slope 35% + granite influence 10%.
-          </p>
-          <p className="firewatch-method__note">
-            Unknown slope no longer produces High heritage risk; it is capped pending review.
-          </p>
-        </section>
+
+  <div className="firewatch-method__formula">
+    <strong>Heritage score</strong>
+    <span>Fuel 45% + slope 25% + heritage type/material 25% + burn context 5%.</span>
+  </div>
+
+  <div className="firewatch-method__formula">
+    <strong>Area score</strong>
+    <span>Fuel 55% + slope 35% + granite influence 10%.</span>
+  </div>
+
+  <p className="firewatch-method__note">
+    Unknown slope is capped pending review and does not automatically produce High heritage risk.
+  </p>
+</section>
       </aside>
 
       <section className="firewatch-map-wrap" aria-label="Interactive map">

--- a/src/pages/RiskMap.tsx
+++ b/src/pages/RiskMap.tsx
@@ -114,9 +114,9 @@ const defaultLayerVisibility: ToggleState = {
 }
 
 const defaultDetails: DetailState = {
-  title: 'Select a heritage place',
+  title: 'Select a map feature',
   intro:
-    'Drag to pan, scroll to zoom, and click a heritage place, burn option, or geology area to inspect source attributes.',
+    'Drag or zoom the map to explore the study area. Click a heritage place, burn option, or geology area to view its details here.',
   metrics: [],
 }
 

--- a/src/pages/RiskMap.tsx
+++ b/src/pages/RiskMap.tsx
@@ -853,11 +853,13 @@ function RiskMap() {
           </div>
         </section>
 
-        <section className="firewatch-card firewatch-details" aria-live="polite">
-          <h2>{details.title}</h2>
-          <p className="firewatch-details__intro">{details.intro}</p>
-          <dl className="firewatch-metric-list">
-            {details.metrics.map((metric) => (
+<section className="firewatch-card firewatch-details" aria-live="polite">
+  <div className="firewatch-details__heading">
+    <span className="firewatch-details__icon" aria-hidden="true">i</span>
+    <h2>{details.title}</h2>
+  </div>
+  <p className="firewatch-details__intro">{details.intro}</p>
+  <dl className="firewatch-metric-list">            {details.metrics.map((metric) => (
               <div key={metric.label} className="firewatch-metric">
                 <dt>{metric.label}</dt>
                 <dd>{metric.value}</dd>

--- a/src/pages/RiskMap.tsx
+++ b/src/pages/RiskMap.tsx
@@ -868,12 +868,14 @@ function RiskMap() {
           </dl>
         </section>
 
-        <section className="firewatch-card firewatch-method">
-          <h2>Score Method</h2>
-          <p>
-            <strong>Heritage score =</strong> fuel 45% + slope 25% + heritage type/material 25% + burn context 5%.
-          </p>
-          <p>
+<section className="firewatch-card firewatch-method">
+  <h2>Score Method</h2>
+  <p className="firewatch-method__intro">
+    These weightings explain how vulnerability scores are calculated for heritage places and surrounding areas.
+  </p>
+  <p>
+    <strong>Heritage score =</strong> fuel 45% + slope 25% + heritage type/material 25% + burn context 5%.
+  </p>          <p>
             <strong>Area score =</strong> fuel 55% + slope 35% + granite influence 10%.
           </p>
           <p className="firewatch-method__note">


### PR DESCRIPTION
## Summary
This PR improves the presentation of the Score Method section on the Risk Map page.

## Changes
- Added a short explanation of what the score weightings represent.
- Separated the heritage score and area score into clearer formula rows.
- Reworded the unknown slope note to make it easier to understand.
- Kept the existing score values unchanged.
- Did not change any scoring logic or backend data processing.

## Testing
- Ran `npm run build`.
- Checked that the Score Method section still renders correctly in the Risk Map side panel.

Closes #100 