### PR TITLE
Add auth edge-case tests

### DIFF
--- a/tests/backend/test_auth_and_assessment.py
+++ b/tests/backend/test_auth_and_assessment.py
@@ -42,6 +42,17 @@ def test_login_rejects_missing_password(client):
     assert payload["error"] == "Password is required"
 
 
+def test_login_rejects_invalid_email_format(client):
+    response = client.post(
+        "/api/login",
+        json={"email": "not-an-email", "password": "secret12"},
+    )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["error"] == "Invalid email format"
+
+
 def test_login_accepts_valid_input(client):
     response = client.post(
         "/api/login",
@@ -51,6 +62,22 @@ def test_login_accepts_valid_input(client):
     assert response.status_code == 200
     payload = response.get_json()
     assert "message" in payload
+
+
+def test_register_trims_username_and_email(client):
+    response = client.post(
+        "/api/register",
+        json={
+            "username": "  test-user  ",
+            "email": "  test@example.com  ",
+            "password": "secret12",
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["user"]["username"] == "test-user"
+    assert payload["user"]["email"] == "test@example.com"
 
 
 def test_site_assessment_validates_required_fields(client):

--- a/tests/backend/test_site_assessment_validation.py
+++ b/tests/backend/test_site_assessment_validation.py
@@ -78,3 +78,51 @@ def test_site_assessment_accepts_floats(client):
     payload = response.get_json()
     assert "score" in payload
     assert "riskLevel" in payload
+
+
+def test_site_assessment_accepts_boundary_values(client):
+    response = client.post(
+        "/api/site-assessment",
+        json={
+            "fuelRisk": 0,
+            "slopeRisk": 100,
+            "heritageTypeRisk": 0,
+            "burnContext": 100,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["score"] == 30
+
+
+@pytest.mark.parametrize(
+    ("fuel", "slope", "heritage", "burn", "expected_level"),
+    [
+        (100, 13, 0, 0, "Low"),
+        (100, 16, 0, 0, "Medium"),
+        (100, 76, 0, 0, "Medium"),
+        (100, 80, 0, 0, "High"),
+    ],
+)
+def test_site_assessment_risk_level_thresholds(
+    client,
+    fuel,
+    slope,
+    heritage,
+    burn,
+    expected_level,
+):
+    response = client.post(
+        "/api/site-assessment",
+        json={
+            "fuelRisk": fuel,
+            "slopeRisk": slope,
+            "heritageTypeRisk": heritage,
+            "burnContext": burn,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["riskLevel"] == expected_level


### PR DESCRIPTION
Summary

Adds auth edge-case coverage for login validation and input trimming on registration.
Improves confidence in request validation without touching backend code.
Adds boundary tests to ensure 0/100 inputs are accepted.
Verifies risk-level thresholds near Low/Medium/High cutoffs.