### PR TITLE
Add heritage identifier and error-path tests for heritage routes

### DIFF
--- a/tests/backend/test_heritage_routes.py
+++ b/tests/backend/test_heritage_routes.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import json
+import sqlite3
+
+from routes import heritage_routes
+
 
 def test_get_sites_returns_count_and_sites(client, seeded_backend_db):
     response = client.get("/api/sites")
@@ -49,6 +54,71 @@ def test_get_site_by_id_returns_404_for_missing_site(client, seeded_backend_db):
     assert response.status_code == 404
     payload = response.get_json()
     assert payload["error"] == "heritage site not found"
+
+
+def test_get_site_by_identifier_returns_site(client, seeded_backend_db):
+    db_path = seeded_backend_db["db_path"]
+    identifier = "FRK-999"
+
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO heritage_sites (
+                id,
+                identifier,
+                name,
+                source,
+                data_source,
+                geometry_json,
+                properties_json,
+                latitude,
+                longitude,
+                heritage_type,
+                fuel_class,
+                slope_degrees,
+                vulnerability_score,
+                vulnerability_level
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "site-2",
+                identifier,
+                "Identifier Site",
+                "register",
+                "DPLH_099",
+                json.dumps({"type": "Point", "coordinates": [150.5, -33.5]}, separators=(",", ":")),
+                json.dumps({"identifier": identifier, "name": "Identifier Site"}, separators=(",", ":")),
+                -33.5,
+                150.5,
+                "Historic",
+                "Forest",
+                12.0,
+                40.0,
+                "Low",
+            ),
+        )
+        connection.commit()
+
+    response = client.get(f"/api/heritage/{identifier}")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["id"] == "site-2"
+    assert payload["identifier"] == identifier
+
+
+def test_get_sites_returns_500_when_loader_fails(client, monkeypatch):
+    def raise_loader_error():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(heritage_routes, "load_heritage_sites_from_db", raise_loader_error)
+
+    response = client.get("/api/heritage")
+
+    assert response.status_code == 500
+    payload = response.get_json()
+    assert payload["error"] == "could not load heritage sites: boom"
 
 
 def test_processed_metadata_returns_seeded_payload(client, seeded_backend_db):


### PR DESCRIPTION
Overview

Add test to ensure [/api/heritage/<identifier>] resolves by identifier as well as id.
Add test for loader failure to assert 500 response and error message.
Keep existing heritage route coverage intact.