### PR TITLE
Enhancement: Implement Fuel Type Breakdown Stacked Bar Chart

### DIFF
--- a/src/pages/ModelInsights.tsx
+++ b/src/pages/ModelInsights.tsx
@@ -216,12 +216,7 @@ import {
   // / Low for the hovered fuel class without picking each segment one by
   // one. Legend sits at the bottom for consistency with the doughnut and
   // the scatter chart.
-  //
-  // The leading underscore marks this value as intentionally unused for
-  // now so tsconfig's noUnusedLocals does not fail the build. It will be
-  // renamed to `fuelTypeByLevelChartOptions` and consumed by the new card
-  // when the JSX is wired up in a follow-up commit.
-  const _fuelTypeByLevelChartOptions = {
+  const fuelTypeByLevelChartOptions = {
     indexAxis: 'y' as const,
     responsive: true,
     maintainAspectRatio: false,
@@ -480,12 +475,7 @@ import {
     // stable order across renders even as the underlying dataset changes.
     // Falls back to total site count as a tie-breaker, then alphabetical,
     // so the order is fully deterministic.
-    //
-    // The leading underscore marks this value as intentionally unused for
-    // now so tsconfig's noUnusedLocals does not fail the build. It will be
-    // renamed to `fuelTypeByLevelChartData` and consumed by the new card
-    // when the JSX is wired up in a follow-up commit.
-    const _fuelTypeByLevelChartData = useMemo(() => {
+    const fuelTypeByLevelChartData = useMemo(() => {
       if (heritageFeatures.length === 0) return null
 
       const countsByFuelClass: Record<string, Record<RiskLevel, number>> = {}
@@ -552,11 +542,13 @@ import {
         {/* Title */}
         <h1 className="text-3xl font-black text-center mb-2">Heritage Fire Vulnerability Model Insights</h1>
 
-        {/* Loading state: four skeleton cards in the same 2x2 grid the real
-            charts will use, so the layout does not jump when data arrives. */}
+        {/* Loading state: five skeleton cards in the same 2-column grid the
+            real charts will use, so the layout does not jump when data
+            arrives. The fifth card (Fuel Type Breakdown) sits on its own
+            row at the bottom, matching the real grid below. */}
         {loading && (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {Array.from({ length: 4 }).map((_, index) => (
+            {Array.from({ length: 5 }).map((_, index) => (
               <div
                 key={index}
                 className="bg-white rounded-xl p-6 h-80 animate-pulse"
@@ -591,9 +583,11 @@ import {
           </div>
         )}
 
-        {/* Charts: 2x2 grid of cards. Each card has a fixed-height chart
-            container so Chart.js (with maintainAspectRatio: false) renders at
-            a predictable size inside the grid. */}
+        {/* Charts: 2-column grid of cards (2x2 for the original four, with
+            the Fuel Type Breakdown card landing on its own row at the
+            bottom). Each card has a fixed-height chart container so
+            Chart.js (with maintainAspectRatio: false) renders at a
+            predictable size inside the grid. */}
         {!loading && !error && (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
 
@@ -653,6 +647,37 @@ import {
                   <Scatter
                     data={slopeVsVulnerabilityChartData}
                     options={slopeVsVulnerabilityChartOptions}
+                  />
+                )}
+              </div>
+            </div>
+
+            {/* Chart 5 - Fuel Type Breakdown (Top Model Driver).
+                Sits on its own row at the bottom of the 2-column grid.
+                The subtitle reads the Fuel weight live from the metadata
+                response so the percentage stays in sync if the backend
+                ever retunes the model weights. Falls back to a static
+                explanation if the weight is missing or non-numeric. */}
+            <div className="bg-white rounded-xl p-6">
+              <h3 className="text-lg font-bold mb-1">
+                Fuel Type Breakdown (Top Model Driver)
+              </h3>
+              <p className="text-sm text-gray-500 mb-4">
+                {(() => {
+                  const fuelWeight =
+                    metadata?.score_formula.heritage_vulnerability.fuel_risk
+                  if (typeof fuelWeight === 'number' && Number.isFinite(fuelWeight)) {
+                    const fuelWeightPercent = Math.round(fuelWeight * 100)
+                    return `Fuel risk is weighted ${fuelWeightPercent}% — sites grouped by fuel class and stacked by vulnerability level.`
+                  }
+                  return 'Heritage sites grouped by fuel class and stacked by vulnerability level.'
+                })()}
+              </p>
+              <div className="h-64">
+                {fuelTypeByLevelChartData && (
+                  <Bar
+                    data={fuelTypeByLevelChartData}
+                    options={fuelTypeByLevelChartOptions}
                   />
                 )}
               </div>

--- a/src/pages/ModelInsights.tsx
+++ b/src/pages/ModelInsights.tsx
@@ -108,6 +108,34 @@ import {
     'No burn option overlap': 70,       // no burn management -> higher risk
   }
 
+  // Fuel class -> reference risk score (0-100). Mirrors the backend
+  // FUEL_TYPE_RISK table in backend/services/risk_normalization.py and is
+  // only used to derive a stable y-axis order for the Fuel Type Breakdown
+  // chart (highest-risk fuel class on top, lowest on bottom). Fuel classes
+  // present in the heritage features but missing from this map fall back to
+  // a score of -Infinity and sort to the bottom, so the chart still renders.
+  // TODO: expose this mapping via /api/processed-metadata so the frontend
+  // and backend cannot drift out of sync.
+  const FUEL_TYPE_RISK_SCORES: Record<string, number> = {
+    'Tall closed forest': 100,
+    'Closed forest': 96,
+    'Pine plantation': 94,
+    'Tall open forest': 92,
+    'Tall shrubland': 88,
+    'Open forest': 86,
+    'Woodland with shrubby understory': 84,
+    'Shrubland': 82,
+    'Low woodland': 67,
+    'Grassland': 62,
+    'Sedgeland': 58,
+    'Cropland': 50,
+    'Wetland': 35,
+    'Sparse grassland': 34,
+    'Built-up': 26,
+    'Bare ground': 12,
+    'Water': 5,
+  }
+
   // Arithmetic mean over an array of finite numbers. Returns 0 for an empty
   // array so chart datasets always render a numeric value (the chart itself
   // can be hidden by the parent when there is no data to show).
@@ -391,6 +419,87 @@ import {
           backgroundColor: LEVEL_COLORS[level],
           pointRadius: 5,
           pointHoverRadius: 7,
+        })),
+      }
+    }, [heritageFeatures])
+
+    // Chart 5 - Fuel Type Breakdown (stacked horizontal bar).
+    // Aggregates heritage features into a Record<fuel_class, Record<RiskLevel, number>>
+    // so each fuel class becomes one bar on the y-axis with three stacked
+    // segments (High / Medium / Low). Filtering mirrors the distinctOptions
+    // helper in HeritagRegistry.tsx: fuel_class values that are missing,
+    // blank after trim, or equal to the "Unknown" fallback are skipped so
+    // they do not pollute the chart with a meaningless category. Features
+    // without a recognised vulnerability_level are also skipped because
+    // they cannot be slotted into a stack segment.
+    //
+    // The y-axis order is driven by FUEL_TYPE_RISK_SCORES (descending),
+    // which keeps the highest-risk fuel class on top and gives the chart a
+    // stable order across renders even as the underlying dataset changes.
+    // Falls back to total site count as a tie-breaker, then alphabetical,
+    // so the order is fully deterministic.
+    //
+    // The leading underscore marks this value as intentionally unused for
+    // now so tsconfig's noUnusedLocals does not fail the build. It will be
+    // renamed to `fuelTypeByLevelChartData` and consumed by the new card
+    // when the JSX is wired up in a follow-up commit.
+    const _fuelTypeByLevelChartData = useMemo(() => {
+      if (heritageFeatures.length === 0) return null
+
+      const countsByFuelClass: Record<string, Record<RiskLevel, number>> = {}
+
+      for (const feature of heritageFeatures) {
+        const rawFuelClass = feature.properties.fuel_class
+        const level = feature.properties.vulnerability_level
+
+        // Skip features with no usable fuel class. trim() guards against
+        // whitespace-only strings; "Unknown" is the documented fallback
+        // produced upstream when the source data is missing.
+        if (typeof rawFuelClass !== 'string') continue
+        const fuelClass = rawFuelClass.trim()
+        if (fuelClass === '' || fuelClass === 'Unknown') continue
+
+        // Skip features that cannot be placed in a High/Medium/Low stack.
+        if (level !== 'High' && level !== 'Medium' && level !== 'Low') continue
+
+        if (!countsByFuelClass[fuelClass]) {
+          countsByFuelClass[fuelClass] = { High: 0, Medium: 0, Low: 0 }
+        }
+        countsByFuelClass[fuelClass][level] += 1
+      }
+
+      const fuelClasses = Object.keys(countsByFuelClass)
+      if (fuelClasses.length === 0) return null
+
+      // Sort by reference risk score (desc), then total site count (desc),
+      // then alphabetical, so the y-axis order is stable and meaningful.
+      const sortedFuelClasses = fuelClasses.sort((a, b) => {
+        const riskA = FUEL_TYPE_RISK_SCORES[a] ?? -Infinity
+        const riskB = FUEL_TYPE_RISK_SCORES[b] ?? -Infinity
+        if (riskA !== riskB) return riskB - riskA
+
+        const totalA =
+          countsByFuelClass[a].High +
+          countsByFuelClass[a].Medium +
+          countsByFuelClass[a].Low
+        const totalB =
+          countsByFuelClass[b].High +
+          countsByFuelClass[b].Medium +
+          countsByFuelClass[b].Low
+        if (totalA !== totalB) return totalB - totalA
+
+        return a.localeCompare(b)
+      })
+
+      return {
+        labels: sortedFuelClasses,
+        datasets: RISK_LEVELS.map((level) => ({
+          label: level,
+          data: sortedFuelClasses.map(
+            (fuelClass) => countsByFuelClass[fuelClass][level]
+          ),
+          backgroundColor: LEVEL_COLORS[level],
+          borderWidth: 0,
         })),
       }
     }, [heritageFeatures])

--- a/src/pages/ModelInsights.tsx
+++ b/src/pages/ModelInsights.tsx
@@ -75,6 +75,11 @@ import {
     vulnerability_score?: number | null
     vulnerability_level?: RiskLevel
     fuel_risk?: number | null
+    // Categorical fuel class (e.g. "Tall closed forest", "Open forest").
+    // Used by the Fuel Type Breakdown stacked bar chart to group heritage
+    // sites by fuel class on the y-axis. Optional because some features in
+    // /api/layers/heritage may have a missing or blank fuel_class.
+    fuel_class?: string
     slope_risk?: number | null
     heritage_type_risk?: number | null
     slope_degrees?: number | null

--- a/src/pages/ModelInsights.tsx
+++ b/src/pages/ModelInsights.tsx
@@ -207,6 +207,48 @@ import {
     },
   }
 
+  // Chart 5 - Fuel Type Breakdown (horizontal stacked bar).
+  // indexAxis: 'y' makes each fuel class a horizontal bar; stacking both
+  // axes turns the three High/Medium/Low datasets into a single stacked
+  // bar per fuel class (the dataset colors come from LEVEL_COLORS in the
+  // data object). interaction.mode: 'index' surfaces all three risk-level
+  // counts in the tooltip together so the reader can compare High / Medium
+  // / Low for the hovered fuel class without picking each segment one by
+  // one. Legend sits at the bottom for consistency with the doughnut and
+  // the scatter chart.
+  //
+  // The leading underscore marks this value as intentionally unused for
+  // now so tsconfig's noUnusedLocals does not fail the build. It will be
+  // renamed to `fuelTypeByLevelChartOptions` and consumed by the new card
+  // when the JSX is wired up in a follow-up commit.
+  const _fuelTypeByLevelChartOptions = {
+    indexAxis: 'y' as const,
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: {
+      mode: 'index' as const,
+      intersect: false,
+    },
+    plugins: {
+      legend: { position: 'bottom' as const },
+    },
+    scales: {
+      x: {
+        stacked: true,
+        beginAtZero: true,
+        title: { display: true, text: 'Heritage sites' },
+        ticks: {
+          // Site counts are integers; suppress fractional gridlines.
+          precision: 0,
+        },
+      },
+      y: {
+        stacked: true,
+        title: { display: true, text: 'Fuel class' },
+      },
+    },
+  }
+
   const ModelInsights = () => {
     const [metadata, setMetadata] = useState<ProcessedMetadata | null>(null)
     const [heritageFeatures, setHeritageFeatures] = useState<HeritageFeature[]>([])

--- a/src/pages/ModelInsights.tsx
+++ b/src/pages/ModelInsights.tsx
@@ -660,7 +660,7 @@ import {
                 explanation if the weight is missing or non-numeric. */}
             <div className="bg-white rounded-xl p-6">
               <h3 className="text-lg font-bold mb-1">
-                Fuel Type Breakdown (Top Model Driver)
+                Heritage Sites by Fuel Type and Vulnerability Level
               </h3>
               <p className="text-sm text-gray-500 mb-4">
                 {(() => {


### PR DESCRIPTION
### Description

This PR implements the "Fuel Type Breakdown" chart functionality. It groups heritage sites by their **Fuel Class** and stacks them by **Vulnerability Level** (High/Medium/Low) to provide a clear visualization of risk distribution across different fuel types.

### Key Changes

* **Type Extension**: Added an optional `fuel_class` field to the `HeritageFeatureProperties` type to support data grouping without TypeScript errors.
* **Data Aggregation**: Introduced a `useMemo` hook to group heritage features into a nested record: `Record<fuel_class, Record<RiskLevel, number>>`.
* Filters out features with missing vulnerability levels.
* Sorts fuel classes by reference risk score (descending) to ensure high-risk categories sit at the top.


* **Chart.js Configuration**: Defined the option object for the new chart.
* Set `indexAxis: 'y'` for horizontal bars and enabled stacking for both axes.
* Optimized tooltips with `interaction: 'index'` to show all risk-level counts simultaneously on hover.


* **UI Component & Layout**:
* Integrated the new chart as the 5th card in the dashboard grid (occupying a new row to maintain the existing 2x2 layout).
* Added dynamic subtitles that render "Fuel risk is weighted XX%" based on live metadata, with fallback logic for non-numeric values.
* Updated the loading skeleton count from 4 to 5 to prevent layout shifts.


* **Refinement**: Renamed the chart title to **"Heritage Sites by Fuel Type and Vulnerability Level"** to improve clarity and self-explanation for new users.

### Technical Details

* **Closes**: #108 
* **No-Impact**: This is a frontend-only change; no backend or routing modifications are required.
* **Code Cleanup**: Temporary underscores used to prevent `noUnusedLocals` errors during the development of separate commits have been removed in the final wiring stage.