### PR TITLE
Docs(Login): Add Acknowledgement of Country to Login Page

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -77,6 +77,23 @@ const Login = () => {
             and heritage practitioners in the Franklin District, Western Australia.
           </p>
 
+          {/* Acknowledgement of Country.
+              Recognises the Wagyl Kaip Noongar people as Traditional
+              Custodians of the Franklin District. Styled as a quote block
+              with a left accent bar to give it visual weight without
+              competing with the hero. */}
+          <div className="mt-8 pl-4 border-l-2 border-[#8B2020]">
+            <div className="text-[10px] font-bold tracking-widest uppercase text-gray-600 mb-2">
+              Acknowledgement of Country
+            </div>
+            <p className="text-xs italic text-gray-400 leading-relaxed">
+              We acknowledge the Wagyl Kaip Noongar people as the Traditional
+              Custodians of the Franklin District, and pay our respects to
+              Elders past and present. We recognise their enduring connection
+              to Country, culture, and community.
+            </p>
+          </div>
+
           {/* Feature bullets */}
           <div className="flex flex-col gap-3 mt-10">
             {[


### PR DESCRIPTION
### Description

This PR adds an **Acknowledgement of Country** block to the login page to recognize the **Wagyl Kaip Noongar** people as the Traditional Custodians of the **Franklin District**. This change ensures the project respects and acknowledges local Indigenous heritage at the main point of entry.

### Key Changes

* **Content Addition**: Inserted a formal Acknowledgement of Country block within the left panel of the Login page.
* **Strategic Placement**: Positioned the block between the **hero copy** and the **feature bullet points** to maintain a logical reading flow.
* **UI/UX Styling**:
* Styled as a **quote block** to distinguish it from standard body text.
* Added a **left accent bar** utilizing the project's primary accent color.
* Balanced visual weight to ensure the acknowledgment is prominent without detracting from the main hero messaging.



### Visual Style

* **Component**: Quote block.
* **Accent**: Left-side bar (Project Accent Color).
* **Hierarchy**: Sub-hero placement for consistent visual anchor.

### Verification Results

* [x] Text correctly identifies the Wagyl Kaip Noongar people.
* [x] Styling remains responsive and doesn't break the layout of the left login panel.
* [x] Visual weight is balanced against existing hero text.

---