### PR TITLE
Bug(sidebar): remove Local Contacts entry from sidebar nav

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -26,6 +26,10 @@ function getInitials(user: AuthUser | null): string {
   return source.slice(0, 2).toUpperCase() || 'G'
 }
 
+// Local Contacts is intentionally not surfaced in the sidebar. It is
+// reached only from the Fire Risk Regulation page via the "Contact
+// Local Planner" call-to-action, so the entry point stays contextual
+// to the regulation workflow.
 const navItems = [
   { section: 'Assessment', links: [
     { to: '/', label: 'Risk Map' },
@@ -35,9 +39,6 @@ const navItems = [
   { section: 'Data', links: [
     { to: '/registry', label: 'Heritage Registry' },
     { to: '/assessment', label: 'Site Assessment' },
-  ]},
-  { section: 'About', links: [
-    { to: '/contacts', label: 'Local Contacts' },
   ]},
 ]
 


### PR DESCRIPTION
## Description

### Context

Currently, "Local Contacts" is accessible directly from the global sidebar navigation. To improve the user experience and maintain a contextual workflow, the entry point should be streamlined. Local Contacts should only be reachable from the **Fire Risk Regulation** page via the **'Contact Local Planner'** button, rather than being persistent globally.

### What's Changed

* **Sidebar Cleanup:** Removed the "Local Contacts" entry item from the sidebar navigation component.
* **Routing Maintained:** Kept the `/contacts` route intact within `App.tsx` to ensure the in-page Call-To-Action (CTA) button continues to function correctly.

---

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

## Verification & Testing

* [x] Verified locally that the "Local Contacts" link is no longer visible in the sidebar navigation.
* [x] Navigated to the *Fire Risk Regulation* page, clicked the 'Contact Local Planner' button, and confirmed it successfully redirects to the `/contacts` path.

---

## Impact

* **Affected Components:** Sidebar navigation UI.
* **Risk Level:** Low. Basic routing remains untouched; only the sidebar entry point was removed.