### PR TITLE
feat(local-contacts): restructure layout and add DBCA government contact support (#113)

### DIFF
--- a/src/pages/LocalContacts.tsx
+++ b/src/pages/LocalContacts.tsx
@@ -1,9 +1,40 @@
 import { Link } from 'react-router-dom'
 
+// Extra organisation that a person is also affiliated with (e.g. WKSN
+// for Sean). Rendered as a small logo + name block at the bottom of a
+// person card.
+type ExtraAffiliation = {
+  label: string
+  orgName: string
+  logoUrl: string
+  logoAlt: string
+}
+
+// A contact representing an individual person (e.g. a UWA researcher).
+// The `kind` field is the discriminator for the ContactEntry union;
+// additional kinds (e.g. an organisation contact such as DBCA) will be
+// introduced in a later change.
+type PersonContact = {
+  kind: 'person'
+  name: string
+  title: string
+  projectRole: string
+  academicRole: string
+  email: string
+  extraAffiliation: ExtraAffiliation | null
+}
+
+// Discriminated union of every kind of entry that can appear on the
+// Local Contacts page. Today only `PersonContact` is a member; the
+// union is introduced now so downstream rendering can switch on
+// `entry.kind` once more kinds are added.
+type ContactEntry = PersonContact
+
 // UWA-based researchers leading the project. Data sourced from
 // issue #82 (Local Contacts).
-const contacts = [
+const contacts: ReadonlyArray<ContactEntry> = [
   {
+    kind: 'person',
     name: 'Sean Winter',
     title: 'Dr, BA PhD W.Aust.',
     projectRole: 'Client / Project Owner',
@@ -18,6 +49,7 @@ const contacts = [
     },
   },
   {
+    kind: 'person',
     name: 'Sven Ouzman',
     title: 'PhD Berkeley, SFHEA',
     projectRole: 'Client / Project Owner',
@@ -26,7 +58,7 @@ const contacts = [
     email: 'sven.ouzman@uwa.edu.au',
     extraAffiliation: null,
   },
-] as const
+]
 
 const LocalContacts = () => {
   return (

--- a/src/pages/LocalContacts.tsx
+++ b/src/pages/LocalContacts.tsx
@@ -30,33 +30,50 @@ type PersonContact = {
 // `entry.kind` once more kinds are added.
 type ContactEntry = PersonContact
 
-// UWA-based researchers leading the project. Data sourced from
-// issue #82 (Local Contacts).
-const contacts: ReadonlyArray<ContactEntry> = [
+// A visually-grouped set of contacts rendered together under a single
+// heading (e.g. "Project Team", "Government & Regulatory"). Sections
+// keep related contacts together and let new categories be added
+// without restructuring the page.
+type ContactSection = {
+  id: string
+  heading: string
+  entries: ReadonlyArray<ContactEntry>
+}
+
+// Page content, grouped into sections. Additional sections (e.g.
+// government authorities) will be added in a later change. Project
+// Team data sourced from issue #82 (Local Contacts).
+const contactSections: ReadonlyArray<ContactSection> = [
   {
-    kind: 'person',
-    name: 'Sean Winter',
-    title: 'Dr, BA PhD W.Aust.',
-    projectRole: 'Client / Project Owner',
-    academicRole: 'Adjunct Lecturer, School of Social Sciences, Archaeology',
-    email: 'sean.winter@uwa.edu.au',
-    extraAffiliation: {
-      label: 'Also affiliated with',
-      orgName: 'Wagyl Kaip Southern Noongar (WKSN) Aboriginal Corporation',
-      logoUrl:
-        'https://images.squarespace-cdn.com/content/v1/61f8e2c584741255f5ca8798/290d1715-85eb-4c72-a7e6-9c59ca2501ca/WKSNLogo.png',
-      logoAlt: 'Wagyl Kaip Southern Noongar logo',
-    },
-  },
-  {
-    kind: 'person',
-    name: 'Sven Ouzman',
-    title: 'PhD Berkeley, SFHEA',
-    projectRole: 'Client / Project Owner',
-    academicRole:
-      'Associate Professor, School of Social Sciences; School of Social Sciences, Archaeology; Centre for Rock Art Research and Management',
-    email: 'sven.ouzman@uwa.edu.au',
-    extraAffiliation: null,
+    id: 'project-team',
+    heading: 'Project Team',
+    entries: [
+      {
+        kind: 'person',
+        name: 'Sean Winter',
+        title: 'Dr, BA PhD W.Aust.',
+        projectRole: 'Client / Project Owner',
+        academicRole: 'Adjunct Lecturer, School of Social Sciences, Archaeology',
+        email: 'sean.winter@uwa.edu.au',
+        extraAffiliation: {
+          label: 'Also affiliated with',
+          orgName: 'Wagyl Kaip Southern Noongar (WKSN) Aboriginal Corporation',
+          logoUrl:
+            'https://images.squarespace-cdn.com/content/v1/61f8e2c584741255f5ca8798/290d1715-85eb-4c72-a7e6-9c59ca2501ca/WKSNLogo.png',
+          logoAlt: 'Wagyl Kaip Southern Noongar logo',
+        },
+      },
+      {
+        kind: 'person',
+        name: 'Sven Ouzman',
+        title: 'PhD Berkeley, SFHEA',
+        projectRole: 'Client / Project Owner',
+        academicRole:
+          'Associate Professor, School of Social Sciences; School of Social Sciences, Archaeology; Centre for Rock Art Research and Management',
+        email: 'sven.ouzman@uwa.edu.au',
+        extraAffiliation: null,
+      },
+    ],
   },
 ]
 
@@ -73,89 +90,99 @@ const LocalContacts = () => {
 
       {/* Subtitle */}
       <p className="text-base font-medium text-gray-700 italic mb-10 text-center">
-        UWA-based researchers leading this project
+        Project leads and relevant authorities for fire risk in Franklin District
       </p>
 
-      {/* Contact Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-5xl mb-10">
-        {contacts.map((person) => (
-          <article
-            key={person.email}
-            className="relative bg-white rounded-2xl shadow-sm overflow-hidden flex flex-col"
-          >
-            {/* Header colour bar */}
-            <div className="h-3 w-full bg-[#8B2020]" />
+      {/* Contact sections — each section renders a heading followed by
+          its own grid of cards. Iterating over `contactSections` keeps
+          the page easily extensible: new groups (e.g. government,
+          emergency services) only need a new entry in the data array. */}
+      {contactSections.map((section) => (
+        <section key={section.id} className="w-full max-w-5xl mb-10">
+          <h2 className="text-sm font-black uppercase tracking-[0.25em] text-gray-700 mb-4">
+            {section.heading}
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {section.entries.map((person) => (
+              <article
+                key={person.email}
+                className="relative bg-white rounded-2xl shadow-sm overflow-hidden flex flex-col"
+              >
+                {/* Header colour bar */}
+                <div className="h-3 w-full bg-[#8B2020]" />
 
-            {/* Project Role badge — pinned top-right of card body */}
-            <span
-              className="absolute top-6 right-5 text-[10px] font-black uppercase tracking-widest bg-[#8B2020] text-white px-2.5 py-1 rounded-full"
-            >
-              Project Owner
-            </span>
-
-            <div className="p-7 flex-1 flex flex-col">
-              {/* Name */}
-              <h2 className="text-2xl font-black text-gray-900 pr-32">
-                {person.name}
-              </h2>
-              {/* Title / qualifications */}
-              <p className="text-sm text-gray-500 mt-1 mb-5">{person.title}</p>
-
-              {/* Project Role */}
-              <div className="mb-4">
-                <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
-                  Project Role
-                </div>
-                <p className="text-sm font-bold text-[#8B2020]">
-                  {person.projectRole}
-                </p>
-              </div>
-
-              {/* Academic Role */}
-              <div className="mb-4">
-                <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
-                  Academic Role
-                </div>
-                <p className="text-sm text-gray-800 leading-relaxed">
-                  {person.academicRole}
-                </p>
-              </div>
-
-              {/* Email */}
-              <div className="mb-4">
-                <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
-                  Email
-                </div>
-                <a
-                  href={`mailto:${person.email}`}
-                  className="text-sm font-medium text-[#1565C0] hover:text-[#0D47A1] hover:underline break-all"
+                {/* Project Role badge — pinned top-right of card body */}
+                <span
+                  className="absolute top-6 right-5 text-[10px] font-black uppercase tracking-widest bg-[#8B2020] text-white px-2.5 py-1 rounded-full"
                 >
-                  {person.email}
-                </a>
-              </div>
+                  Project Owner
+                </span>
 
-              {/* Extra affiliation (e.g. WKSN for Sean) */}
-              {person.extraAffiliation && (
-                <div className="mt-auto pt-5 border-t border-gray-200">
-                  <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-2">
-                    {person.extraAffiliation.label}
-                  </div>
-                  <div className="flex items-center gap-3 rounded-lg bg-[#F0EDE8] px-3 py-2.5">
-                    <img
-                      src={person.extraAffiliation.logoUrl}
-                      alt={person.extraAffiliation.logoAlt}
-                      className="w-10 h-10 rounded object-contain bg-white p-1 flex-shrink-0"
-                    />
-                    <p className="text-sm font-semibold text-gray-900 leading-tight">
-                      {person.extraAffiliation.orgName}
+                <div className="p-7 flex-1 flex flex-col">
+                  {/* Name — h3 because the section heading above is the h2. */}
+                  <h3 className="text-2xl font-black text-gray-900 pr-32">
+                    {person.name}
+                  </h3>
+                  {/* Title / qualifications */}
+                  <p className="text-sm text-gray-500 mt-1 mb-5">{person.title}</p>
+
+                  {/* Project Role */}
+                  <div className="mb-4">
+                    <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
+                      Project Role
+                    </div>
+                    <p className="text-sm font-bold text-[#8B2020]">
+                      {person.projectRole}
                     </p>
                   </div>
+
+                  {/* Academic Role */}
+                  <div className="mb-4">
+                    <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
+                      Academic Role
+                    </div>
+                    <p className="text-sm text-gray-800 leading-relaxed">
+                      {person.academicRole}
+                    </p>
+                  </div>
+
+                  {/* Email */}
+                  <div className="mb-4">
+                    <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
+                      Email
+                    </div>
+                    <a
+                      href={`mailto:${person.email}`}
+                      className="text-sm font-medium text-[#1565C0] hover:text-[#0D47A1] hover:underline break-all"
+                    >
+                      {person.email}
+                    </a>
+                  </div>
+
+                  {/* Extra affiliation (e.g. WKSN for Sean) */}
+                  {person.extraAffiliation && (
+                    <div className="mt-auto pt-5 border-t border-gray-200">
+                      <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-2">
+                        {person.extraAffiliation.label}
+                      </div>
+                      <div className="flex items-center gap-3 rounded-lg bg-[#F0EDE8] px-3 py-2.5">
+                        <img
+                          src={person.extraAffiliation.logoUrl}
+                          alt={person.extraAffiliation.logoAlt}
+                          className="w-10 h-10 rounded object-contain bg-white p-1 flex-shrink-0"
+                        />
+                        <p className="text-sm font-semibold text-gray-900 leading-tight">
+                          {person.extraAffiliation.orgName}
+                        </p>
+                      </div>
+                    </div>
+                  )}
                 </div>
-              )}
-            </div>
-          </article>
-        ))}
-      </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      ))}
 
       {/* Back link */}
       <Link

--- a/src/pages/LocalContacts.tsx
+++ b/src/pages/LocalContacts.tsx
@@ -11,9 +11,7 @@ type ExtraAffiliation = {
 }
 
 // A contact representing an individual person (e.g. a UWA researcher).
-// The `kind` field is the discriminator for the ContactEntry union;
-// additional kinds (e.g. an organisation contact such as DBCA) will be
-// introduced in a later change.
+// The `kind` field is the discriminator for the ContactEntry union.
 type PersonContact = {
   kind: 'person'
   name: string
@@ -24,11 +22,45 @@ type PersonContact = {
   extraAffiliation: ExtraAffiliation | null
 }
 
+// A single off-site link surfaced on an organisation card (e.g. a link
+// to a department's "Today's burns" page). `description` is an optional
+// one-liner explaining why the link is relevant.
+type RelevantLink = {
+  label: string
+  url: string
+  description?: string
+}
+
+// A contact representing an institution (e.g. a government department)
+// rather than a named person. Organisation cards typically expose a
+// general enquiries phone number, a website, an online contact form,
+// and any topic-relevant links. `id` is used as the React key in the
+// renderer since organisations do not carry a personal email.
+type OrganisationContact = {
+  kind: 'organisation'
+  id: string
+  orgName: string
+  affiliation: string
+  badgeLabel: string
+  phone: {
+    number: string
+    note?: string
+  }
+  website: {
+    url: string
+    display: string
+  }
+  contactForm: {
+    url: string
+    display?: string
+  }
+  relevantLinks: ReadonlyArray<RelevantLink>
+}
+
 // Discriminated union of every kind of entry that can appear on the
-// Local Contacts page. Today only `PersonContact` is a member; the
-// union is introduced now so downstream rendering can switch on
-// `entry.kind` once more kinds are added.
-type ContactEntry = PersonContact
+// Local Contacts page. The renderer switches on `entry.kind` to pick
+// the matching card component.
+type ContactEntry = PersonContact | OrganisationContact
 
 // A visually-grouped set of contacts rendered together under a single
 // heading (e.g. "Project Team", "Government & Regulatory"). Sections
@@ -154,6 +186,119 @@ const PersonCard = ({ person }: { person: PersonContact }) => (
   </article>
 )
 
+// Card UI for an organisation contact (e.g. a government department).
+// Mirrors the visual language of PersonCard so the two card types feel
+// like siblings, but uses a green accent (instead of the project-owner
+// red) and org-specific fields so users can tell at a glance that the
+// contact is institutional rather than an individual.
+const OrganisationCard = ({ org }: { org: OrganisationContact }) => {
+  // tel: URIs should contain only digits and an optional leading `+`,
+  // so strip the human-readable spaces and brackets from the display
+  // number before using it as an href.
+  const telHref = `tel:${org.phone.number.replace(/[^\d+]/g, '')}`
+
+  return (
+    <article className="relative bg-white rounded-2xl shadow-sm overflow-hidden flex flex-col">
+      {/* Header colour bar — green to differentiate from project-owner cards. */}
+      <div className="h-3 w-full bg-[#2E7D32]" />
+
+      {/* Category badge — pinned top-right of card body */}
+      <span className="absolute top-6 right-5 text-[10px] font-black uppercase tracking-widest bg-[#2E7D32] text-white px-2.5 py-1 rounded-full">
+        {org.badgeLabel}
+      </span>
+
+      <div className="p-7 flex-1 flex flex-col">
+        {/* Organisation name — h3 because the section heading above is the h2. */}
+        <h3 className="text-2xl font-black text-gray-900 pr-32">
+          {org.orgName}
+        </h3>
+        {/* Affiliation / jurisdiction (e.g. "Government of Western Australia") */}
+        <p className="text-sm text-gray-500 mt-1 mb-5">{org.affiliation}</p>
+
+        {/* Phone */}
+        <div className="mb-4">
+          <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
+            Phone
+          </div>
+          <a
+            href={telHref}
+            className="text-sm font-medium text-[#1565C0] hover:text-[#0D47A1] hover:underline"
+          >
+            {org.phone.number}
+          </a>
+          {org.phone.note && (
+            <p className="text-xs text-gray-500 mt-0.5">{org.phone.note}</p>
+          )}
+        </div>
+
+        {/* Website */}
+        <div className="mb-4">
+          <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
+            Website
+          </div>
+          <a
+            href={org.website.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-medium text-[#1565C0] hover:text-[#0D47A1] hover:underline break-all"
+          >
+            {org.website.display} ↗
+          </a>
+        </div>
+
+        {/* Contact form — most government departments publish a web
+            form rather than a public enquiries inbox. */}
+        <div className="mb-4">
+          <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
+            Contact form
+          </div>
+          <a
+            href={org.contactForm.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-medium text-[#1565C0] hover:text-[#0D47A1] hover:underline break-all"
+          >
+            {org.contactForm.display ?? 'Submit an enquiry'} ↗
+          </a>
+        </div>
+
+        {/* Relevant links — pinned to the bottom of the card so the
+            block lines up visually with PersonCard's extra-affiliation
+            block. Hidden entirely when there are no links to show. */}
+        {org.relevantLinks.length > 0 && (
+          <div className="mt-auto pt-5 border-t border-gray-200">
+            <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-2">
+              Relevant links
+            </div>
+            <ul className="space-y-2">
+              {org.relevantLinks.map((link) => (
+                <li
+                  key={link.url}
+                  className="rounded-lg bg-[#F0EDE8] px-3 py-2.5"
+                >
+                  <a
+                    href={link.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm font-semibold text-[#1565C0] hover:text-[#0D47A1] hover:underline"
+                  >
+                    {link.label} ↗
+                  </a>
+                  {link.description && (
+                    <p className="text-xs text-gray-600 mt-0.5">
+                      {link.description}
+                    </p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </article>
+  )
+}
+
 const LocalContacts = () => {
   return (
     <div
@@ -180,9 +325,13 @@ const LocalContacts = () => {
             {section.heading}
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {section.entries.map((person) => (
-              <PersonCard key={person.email} person={person} />
-            ))}
+            {section.entries.map((entry) =>
+              entry.kind === 'person' ? (
+                <PersonCard key={entry.email} person={entry} />
+              ) : (
+                <OrganisationCard key={entry.id} org={entry} />
+              ),
+            )}
           </div>
         </section>
       ))}

--- a/src/pages/LocalContacts.tsx
+++ b/src/pages/LocalContacts.tsx
@@ -77,6 +77,83 @@ const contactSections: ReadonlyArray<ContactSection> = [
   },
 ]
 
+// Card UI for a single person contact (e.g. a UWA project owner).
+// Extracted from the page renderer so the section loop can stay focused
+// on layout, and so a second card variant (organisation) can sit
+// alongside this one in a later change without crowding the JSX.
+const PersonCard = ({ person }: { person: PersonContact }) => (
+  <article className="relative bg-white rounded-2xl shadow-sm overflow-hidden flex flex-col">
+    {/* Header colour bar */}
+    <div className="h-3 w-full bg-[#8B2020]" />
+
+    {/* Project Role badge — pinned top-right of card body */}
+    <span className="absolute top-6 right-5 text-[10px] font-black uppercase tracking-widest bg-[#8B2020] text-white px-2.5 py-1 rounded-full">
+      Project Owner
+    </span>
+
+    <div className="p-7 flex-1 flex flex-col">
+      {/* Name — h3 because the section heading above is the h2. */}
+      <h3 className="text-2xl font-black text-gray-900 pr-32">
+        {person.name}
+      </h3>
+      {/* Title / qualifications */}
+      <p className="text-sm text-gray-500 mt-1 mb-5">{person.title}</p>
+
+      {/* Project Role */}
+      <div className="mb-4">
+        <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
+          Project Role
+        </div>
+        <p className="text-sm font-bold text-[#8B2020]">
+          {person.projectRole}
+        </p>
+      </div>
+
+      {/* Academic Role */}
+      <div className="mb-4">
+        <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
+          Academic Role
+        </div>
+        <p className="text-sm text-gray-800 leading-relaxed">
+          {person.academicRole}
+        </p>
+      </div>
+
+      {/* Email */}
+      <div className="mb-4">
+        <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
+          Email
+        </div>
+        <a
+          href={`mailto:${person.email}`}
+          className="text-sm font-medium text-[#1565C0] hover:text-[#0D47A1] hover:underline break-all"
+        >
+          {person.email}
+        </a>
+      </div>
+
+      {/* Extra affiliation (e.g. WKSN for Sean) */}
+      {person.extraAffiliation && (
+        <div className="mt-auto pt-5 border-t border-gray-200">
+          <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-2">
+            {person.extraAffiliation.label}
+          </div>
+          <div className="flex items-center gap-3 rounded-lg bg-[#F0EDE8] px-3 py-2.5">
+            <img
+              src={person.extraAffiliation.logoUrl}
+              alt={person.extraAffiliation.logoAlt}
+              className="w-10 h-10 rounded object-contain bg-white p-1 flex-shrink-0"
+            />
+            <p className="text-sm font-semibold text-gray-900 leading-tight">
+              {person.extraAffiliation.orgName}
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  </article>
+)
+
 const LocalContacts = () => {
   return (
     <div
@@ -104,81 +181,7 @@ const LocalContacts = () => {
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             {section.entries.map((person) => (
-              <article
-                key={person.email}
-                className="relative bg-white rounded-2xl shadow-sm overflow-hidden flex flex-col"
-              >
-                {/* Header colour bar */}
-                <div className="h-3 w-full bg-[#8B2020]" />
-
-                {/* Project Role badge — pinned top-right of card body */}
-                <span
-                  className="absolute top-6 right-5 text-[10px] font-black uppercase tracking-widest bg-[#8B2020] text-white px-2.5 py-1 rounded-full"
-                >
-                  Project Owner
-                </span>
-
-                <div className="p-7 flex-1 flex flex-col">
-                  {/* Name — h3 because the section heading above is the h2. */}
-                  <h3 className="text-2xl font-black text-gray-900 pr-32">
-                    {person.name}
-                  </h3>
-                  {/* Title / qualifications */}
-                  <p className="text-sm text-gray-500 mt-1 mb-5">{person.title}</p>
-
-                  {/* Project Role */}
-                  <div className="mb-4">
-                    <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
-                      Project Role
-                    </div>
-                    <p className="text-sm font-bold text-[#8B2020]">
-                      {person.projectRole}
-                    </p>
-                  </div>
-
-                  {/* Academic Role */}
-                  <div className="mb-4">
-                    <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
-                      Academic Role
-                    </div>
-                    <p className="text-sm text-gray-800 leading-relaxed">
-                      {person.academicRole}
-                    </p>
-                  </div>
-
-                  {/* Email */}
-                  <div className="mb-4">
-                    <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-1">
-                      Email
-                    </div>
-                    <a
-                      href={`mailto:${person.email}`}
-                      className="text-sm font-medium text-[#1565C0] hover:text-[#0D47A1] hover:underline break-all"
-                    >
-                      {person.email}
-                    </a>
-                  </div>
-
-                  {/* Extra affiliation (e.g. WKSN for Sean) */}
-                  {person.extraAffiliation && (
-                    <div className="mt-auto pt-5 border-t border-gray-200">
-                      <div className="text-[10px] font-bold tracking-widest text-gray-500 uppercase mb-2">
-                        {person.extraAffiliation.label}
-                      </div>
-                      <div className="flex items-center gap-3 rounded-lg bg-[#F0EDE8] px-3 py-2.5">
-                        <img
-                          src={person.extraAffiliation.logoUrl}
-                          alt={person.extraAffiliation.logoAlt}
-                          className="w-10 h-10 rounded object-contain bg-white p-1 flex-shrink-0"
-                        />
-                        <p className="text-sm font-semibold text-gray-900 leading-tight">
-                          {person.extraAffiliation.orgName}
-                        </p>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </article>
+              <PersonCard key={person.email} person={person} />
             ))}
           </div>
         </section>

--- a/src/pages/LocalContacts.tsx
+++ b/src/pages/LocalContacts.tsx
@@ -72,9 +72,11 @@ type ContactSection = {
   entries: ReadonlyArray<ContactEntry>
 }
 
-// Page content, grouped into sections. Additional sections (e.g.
-// government authorities) will be added in a later change. Project
-// Team data sourced from issue #82 (Local Contacts).
+// Page content, grouped into sections. Order matters: the Project Team
+// is the primary point of contact, with Government & Regulatory shown
+// below as a secondary referral. Project Team data sourced from issue
+// #82 (Local Contacts); DBCA data sourced from the official website
+// (https://www.dbca.wa.gov.au).
 const contactSections: ReadonlyArray<ContactSection> = [
   {
     id: 'project-team',
@@ -104,6 +106,39 @@ const contactSections: ReadonlyArray<ContactSection> = [
           'Associate Professor, School of Social Sciences; School of Social Sciences, Archaeology; Centre for Rock Art Research and Management',
         email: 'sven.ouzman@uwa.edu.au',
         extraAffiliation: null,
+      },
+    ],
+  },
+  {
+    id: 'government-regulatory',
+    heading: 'Government & Regulatory',
+    entries: [
+      {
+        kind: 'organisation',
+        id: 'dbca',
+        orgName:
+          'Department of Biodiversity, Conservation and Attractions',
+        affiliation: 'Government of Western Australia',
+        badgeLabel: 'Government Agency',
+        phone: {
+          number: '(08) 9219 9000',
+          note: 'General enquiries · Mon–Fri',
+        },
+        website: {
+          url: 'https://www.dbca.wa.gov.au',
+          display: 'dbca.wa.gov.au',
+        },
+        contactForm: {
+          url: 'https://www.dbca.wa.gov.au/contact-us',
+          display: 'dbca.wa.gov.au/contact-us',
+        },
+        relevantLinks: [
+          {
+            label: "Today's burns",
+            url: 'https://www.dbca.wa.gov.au/management/fire/prescribed-burning/todays-burns',
+            description: 'Current prescribed burn program updates',
+          },
+        ],
       },
     ],
   },
@@ -324,7 +359,16 @@ const LocalContacts = () => {
           <h2 className="text-sm font-black uppercase tracking-[0.25em] text-gray-700 mb-4">
             {section.heading}
           </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {/* Single-entry sections are centred and constrained so the
+              lone card does not float awkwardly in one half of an
+              otherwise empty 2-column grid. */}
+          <div
+            className={
+              section.entries.length === 1
+                ? 'grid grid-cols-1 gap-6 md:max-w-lg md:mx-auto'
+                : 'grid grid-cols-1 md:grid-cols-2 gap-6'
+            }
+          >
             {section.entries.map((entry) =>
               entry.kind === 'person' ? (
                 <PersonCard key={entry.email} person={entry} />


### PR DESCRIPTION
#### 1. Description

This PR introduces a comprehensive architectural refactoring and feature expansion for the `local-contacts` module. By leveraging a typed discriminated union, normalizing the page's semantic hierarchy, and decoupling components, the module is now highly extensible.

Building on top of this refactor, a new `OrganisationCard` component has been implemented, and the official contact channels for the Department of Biodiversity, Conservation and Attractions (DBCA) of Western Australia have been successfully integrated.

**Closes #113**

---

#### 2. Type of Change

* [x] **Refactor**: Non-breaking, type-level scaffoldings and JSX decoupling with no immediate runtime or visual regressions.
* [x] **Feature**: Introduced `OrganisationCard` and registered the official DBCA government contact under a newly created regulatory section.

---

#### 3. Detailed Commit Breakdown

1. **introduce typed discriminated union for contact entries** `a0abd1e`
* Added `ExtraAffiliation`, `PersonContact`, and `ContactEntry` types.
* Re-typed the existing UMA entries array as a `ReadonlyArray<ContactEntry>` instead of carrying a loose type assertion. This type-level scaffolding ensures safe rendering branches for incoming non-person contact kinds.


2. **group entries into sections with headings** `c883efc`
* Introduced a `ContactSection` type structure `({ id, heading, entries })` and wrapped the existing UMA entries into a standalone `"Project Team"` section.
* Refactored the renderer to iterate through `contactSections`, emitting an explicit `<section>` wrapper and an `<h2>` heading for each group.
* Demoted the individual's name inside the card from `<h2>` to `<h3>` to enforce a clean, accessible `h1 -> h2 -> h3` document outline.
* Updated the page subtitle to *"Project leads and relevant authorities for fire risk in Franklin District"* to reflect that the page is no longer strictly scoped to UWA researchers.


3. **extract PersonCard into a dedicated component** `4771597`
* Extracted the inline person-card JSX out of `LocalContacts` into a small, focused file-local `PersonCard` component.
* Cleaned up the section loop to call `<PersonCard key={person.email} person={person} />` instead of inlining full article markups, separating card internals from section layout constraints.


4. **add OrganisationCard component for non-person contacts** `327b143`
* Extended the `ContactEntry` union with an `OrganisationContact` variant (surfacing fields for phone, website, online contact forms, and relevant off-site links) and built a sibling `OrganisationCard` component to handle its rendering.
* The layout mirrors `PersonCard` for visual consistency but applies a **green (`#2E7D32`) accent** instead of the project-owner red, allowing users to instantly tell that the contact is institutional. All external links open safely in a new tab with `rel="noopener noreferrer"`.


5. **add DBCA government contact under Government & Regulatory section** `9bc5548`
* Formally registered the Department of Biodiversity, Conservation and Attractions (Government of Western Australia) as an active organisation contact.
* Placed it under a brand new `"Government & Regulatory"` section positioned beneath the existing Project Team grid.
* Surfaced vital contact channels: General enquiries phone `(08) 9219 9000`, official website, contact form, and a direct link to the *“Today's burns”* prescribed-burning program.
* Tweaked the layout grid: when a section contains only a single entry, the card automatically centers and constrains its width on `md` screens and above, preventing it from looking awkwardly stretched or left-aligned in an empty 2-column grid.



---

#### 4. Verification & Code Stats

* **File Changes**: 1 file changed, **`+358 additions`**, **`-103 deletions`**.
* **Layout & Responsiveness**: Verified that single-card sections center gracefully on desktop viewports, while multi-card groups properly tile into standard responsive grids with zero design breakages.
* **Semantic Hierarchy**: Confirmed proper accessibility tree alignment (`h1` for page title, `h2` for structural sections, `h3` for entity titles).