### PR TITLE
feat(branding): prefix product name with 'Heritage'(based on client email on 18/05/2026)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>it-capstone-5206---group-10</title>
+    <!-- Browser tab title: client-requested brand name including "Heritage". -->
+    <title>Heritage Fire Vulnerability Assessment Tool</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -75,8 +75,10 @@ const Sidebar = () => {
             </svg>
           </div>
           <div>
+            {/* Sidebar brand: client feedback asked us to prefix the
+                product name with "Heritage" so the scope is clearer. */}
             <div className="text-xs font-extrabold tracking-widest uppercase leading-tight">
-              Fire Vulnerability<br />Assessment Tool
+              Heritage Fire<br />Vulnerability<br />Assessment Tool
             </div>
             <div className="text-[11px] text-gray-500 mt-1">Franklin District · WA</div>
           </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -59,8 +59,11 @@ const Login = () => {
               </svg>
             </div>
             <div>
+              {/* Brand wordmark on the login hero panel. "Heritage"
+                  was added per client feedback to align with the
+                  sidebar branding across the app. */}
               <div className="text-xs font-extrabold text-white uppercase tracking-widest leading-tight">
-                Fire Vulnerability<br />Assessment Tool
+                Heritage Fire<br />Vulnerability<br />Assessment Tool
               </div>
               <div className="text-[11px] text-gray-500 mt-1">Franklin District · WA</div>
             </div>
@@ -197,7 +200,8 @@ const Login = () => {
           </div>
 
           <div className="text-xs text-gray-700">
-            © 2026 Fire Vulnerability Assessment Tool · Franklin District
+            {/* Footer copyright line — keep brand string in sync with sidebar/title. */}
+            © 2026 Heritage Fire Vulnerability Assessment Tool · Franklin District
           </div>
         </div>
       </div>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -62,8 +62,11 @@ const Register = () => {
               </svg>
             </div>
             <div>
+              {/* Brand wordmark on the register hero panel. "Heritage"
+                  was added per client feedback to align with the
+                  sidebar branding across the app. */}
               <div className="text-xs font-extrabold text-white uppercase tracking-widest leading-tight">
-                Fire Vulnerability<br />Assessment Tool
+                Heritage Fire<br />Vulnerability<br />Assessment Tool
               </div>
               <div className="text-[11px] text-gray-500 mt-1">Franklin District · WA</div>
             </div>
@@ -170,7 +173,8 @@ const Register = () => {
           </div>
 
           <div className="text-xs text-gray-700">
-            © 2026 Fire Vulnerability Assessment Tool · Franklin District
+            {/* Footer copyright line — keep brand string in sync with sidebar/title. */}
+            © 2026 Heritage Fire Vulnerability Assessment Tool · Franklin District
           </div>
         </div>
       </div>


### PR DESCRIPTION
Per client feedback, rename the website brand from

'Fire Vulnerability Assessment Tool' to

'Heritage Fire Vulnerability Assessment Tool' so the

heritage scope of the product is reflected in the name.

Updated:

- index.html              browser tab title

- Sidebar.tsx             sidebar wordmark

- Login.tsx               hero wordmark + footer copyright

- Register.tsx            hero wordmark + footer copyright