### PR TITLE
Improve heritage site popup details

### DIFF
--- a/src/pages/RiskMap.css
+++ b/src/pages/RiskMap.css
@@ -465,3 +465,32 @@
 .firewatch-method__note {
   margin: 0;
 }
+
+.firewatch-popup {
+  min-width: 210px;
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.firewatch-popup strong {
+  display: block;
+  margin-bottom: 3px;
+  font-size: 14px;
+  color: #202124;
+}
+
+.firewatch-popup__details {
+  margin-top: 8px;
+  padding-top: 7px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.firewatch-popup__details div {
+  margin-bottom: 4px;
+  color: #333;
+}
+
+.firewatch-popup__details span {
+  font-weight: 700;
+  color: #555;
+}

--- a/src/pages/RiskMap.tsx
+++ b/src/pages/RiskMap.tsx
@@ -135,6 +135,27 @@ function formatValue(value: unknown, fallback = 'Unknown') {
   return String(value)
 }
 
+function formatSlope(value?: number | null) {
+  return typeof value === 'number' ? `${value.toFixed(2)} deg` : 'Unknown'
+}
+
+function buildHeritagePopup(properties: HeritageProperties) {
+  return `
+    <div class="firewatch-popup">
+      <strong>${formatValue(properties.name, 'Heritage place')}</strong>
+      <div>${formatValue(properties.heritage_kind, 'Heritage')} heritage</div>
+
+      <div class="firewatch-popup__details">
+        <div><span>Name:</span> ${formatValue(properties.name)}</div>
+        <div><span>Region / LGA:</span> ${formatValue(properties.region)}</div>
+        <div><span>Slope:</span> ${formatSlope(properties.slope_degrees)}</div>
+        <div><span>Risk level:</span> ${formatValue(properties.vulnerability_level)}</div>
+        <div><span>Score:</span> ${formatValue(properties.vulnerability_score)}/100</div>
+      </div>
+    </div>
+  `
+}
+
 function loadExternalStylesheet(id: string, href: string) {
   if (document.getElementById(id)) return
 
@@ -513,12 +534,7 @@ function RiskMap() {
         onEachFeature: (feature: GeoFeature, layer: any) => {
           const properties = feature.properties as HeritageProperties
           layer.on('click', () => setHeritageDetails(properties))
-          layer.bindPopup(
-            `<strong>${formatValue(properties.name, 'Heritage place')}</strong><br>${formatValue(
-              properties.heritage_kind,
-              'Heritage'
-            )} heritage`
-          )
+          layer.bindPopup(buildHeritagePopup(properties))
         },
         pane: 'heritagePane',
       }
@@ -541,12 +557,7 @@ function RiskMap() {
           })
 
           marker.on('click', () => setHeritageDetails(properties))
-          marker.bindPopup(
-            `<strong>${formatValue(properties.name, 'Heritage place')}</strong><br>${formatValue(
-              properties.heritage_kind,
-              'Heritage'
-            )} heritage`
-          )
+          marker.bindPopup(buildHeritagePopup(properties))
           return marker
         })
         .filter(Boolean)


### PR DESCRIPTION
## Summary

This PR improves the Risk Map heritage site popup by showing more key site information when a heritage marker is clicked.

## Changes

- Added site name, region/LGA, slope, risk level, and vulnerability score to the heritage popup.
- Reused the same heritage site properties already used by the details panel.
- Added light popup styling for better readability.

## Testing

- Confirmed the Risk Map still loads correctly.
- Confirmed heritage markers can still be clicked.
- Confirmed the left-side details panel still works.
- Confirmed layer controls and filters were not changed.