### PR TITLE
Clientfb/login/180526

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -41,8 +41,16 @@ const Login = () => {
   return (
     <div className="grid grid-cols-2 min-h-screen">
 
-      {/* LEFT — branding */}
-      <div className="bg-[#1A1A1A] px-12 py-12 flex flex-col justify-between">
+      {/* LEFT — branding.
+          Panel background lifted from #1A1A1A to #2A2A2A per client
+          feedback ("the black background makes some of the text hard
+          to read"). The shift keeps the dark, sidebar-style brand
+          feel but raises body-text contrast above the WCAG AA 4.5:1
+          threshold when paired with the lighter gray text classes
+          used below. Inner cards/borders are bumped proportionally
+          (#303030 / #3A3A3A) to preserve the subtle "elevated card"
+          relationship the sidebar uses (#202020 on #1A1A1A). */}
+      <div className="bg-[#2A2A2A] px-12 py-12 flex flex-col justify-between">
         <div>
           {/* Brand */}
           <div className="flex items-start gap-3 mb-12">
@@ -65,7 +73,7 @@ const Login = () => {
               <div className="text-xs font-extrabold text-white uppercase tracking-widest leading-tight">
                 Heritage Fire<br />Vulnerability<br />Assessment Tool
               </div>
-              <div className="text-[11px] text-gray-500 mt-1">Franklin District · WA</div>
+              <div className="text-[11px] text-gray-300 mt-1">Franklin District · WA</div>
             </div>
           </div>
 
@@ -75,7 +83,7 @@ const Login = () => {
             <span className="text-[#8B2020]">Aboriginal Heritage</span><br />
             from Fire Risk
           </h1>
-          <p className="text-sm text-gray-500 leading-relaxed">
+          <p className="text-sm text-gray-300 leading-relaxed">
             A web-based tool for land managers, indigenous rangers,
             and heritage practitioners in the Franklin District, Western Australia.
           </p>
@@ -86,10 +94,10 @@ const Login = () => {
               with a left accent bar to give it visual weight without
               competing with the hero. */}
           <div className="mt-8 pl-4 border-l-2 border-[#8B2020]">
-            <div className="text-[10px] font-bold tracking-widest uppercase text-gray-600 mb-2">
+            <div className="text-[10px] font-bold tracking-widest uppercase text-gray-300 mb-2">
               Acknowledgement of Country
             </div>
-            <p className="text-xs italic text-gray-400 leading-relaxed">
+            <p className="text-xs italic text-gray-300 leading-relaxed">
               We acknowledge the Wagyl Kaip Noongar people as the Traditional
               Custodians of the Franklin District, and pay our respects to
               Elders past and present. We recognise their enduring connection
@@ -106,7 +114,7 @@ const Login = () => {
             ].map((item) => (
               <div key={item} className="flex items-center gap-3">
                 <div className="w-2 h-2 rounded-full bg-[#8B2020] flex-shrink-0" />
-                <span className="text-xs text-gray-500">{item}</span>
+                <span className="text-xs text-gray-300">{item}</span>
               </div>
             ))}
           </div>
@@ -116,7 +124,7 @@ const Login = () => {
               disabled so users can read the location at a glance without
               accidentally panning/zooming. */}
           <div
-            className="mt-8 rounded-md overflow-hidden border border-[#2A2A2A]"
+            className="mt-8 rounded-md overflow-hidden border border-[#3A3A3A]"
             style={{ height: 200 }}
           >
             <MapContainer
@@ -159,11 +167,11 @@ const Login = () => {
         <div>
           {/* Project Partners */}
           <div className="mb-6">
-            <div className="text-[10px] font-bold tracking-widest uppercase text-gray-600 mb-2">
+            <div className="text-[10px] font-bold tracking-widest uppercase text-gray-300 mb-2">
               Project Partners
             </div>
             <div className="space-y-2">
-              <div className="flex items-center gap-2 rounded-md border border-[#2A2A2A] bg-[#202020] px-2 py-2">
+              <div className="flex items-center gap-2 rounded-md border border-[#3A3A3A] bg-[#303030] px-2 py-2">
                 <img
                   src="https://images.squarespace-cdn.com/content/v1/61f8e2c584741255f5ca8798/290d1715-85eb-4c72-a7e6-9c59ca2501ca/WKSNLogo.png"
                   alt="Wagyl Kaip South Noongar logo"
@@ -171,10 +179,10 @@ const Login = () => {
                 />
                 <div>
                   <div className="text-[11px] font-semibold text-white leading-tight">Wagyl Kaip</div>
-                  <div className="text-[10px] text-gray-500 leading-tight">Project Partner</div>
+                  <div className="text-[10px] text-gray-300 leading-tight">Project Partner</div>
                 </div>
               </div>
-              <div className="flex items-center gap-2 rounded-md border border-[#2A2A2A] bg-[#202020] px-2 py-2">
+              <div className="flex items-center gap-2 rounded-md border border-[#3A3A3A] bg-[#303030] px-2 py-2">
                 <img
                   src="https://www.uwa.edu.au/_assets/favicon512.png"
                   alt="University of Western Australia logo"
@@ -182,7 +190,7 @@ const Login = () => {
                 />
                 <div>
                   <div className="text-[11px] font-semibold text-white leading-tight">University of Western Australia</div>
-                  <div className="text-[10px] text-gray-500 leading-tight">Project Partner</div>
+                  <div className="text-[10px] text-gray-300 leading-tight">Project Partner</div>
                 </div>
               </div>
             </div>
@@ -193,14 +201,17 @@ const Login = () => {
               the tool follows, and the conditions of use. Logos are not
               repeated here because they already appear in the Project
               Partners cards above. */}
-          <div className="text-[11px] text-gray-500 leading-relaxed mb-4">
+          <div className="text-[11px] text-gray-300 leading-relaxed mb-4">
             <p>Developed with Wagyl Kaip and The University of Western Australia.</p>
             <p>This tool respects ICIP and IDaS principles.</p>
             <p>For authorised research/project use only. Do not misuse, redistribute, or expose sensitive heritage data.</p>
           </div>
 
-          <div className="text-xs text-gray-700">
-            {/* Footer copyright line — keep brand string in sync with sidebar/title. */}
+          <div className="text-xs text-gray-400">
+            {/* Footer copyright line — keep brand string in sync with sidebar/title.
+                Colour bumped from text-gray-700 to text-gray-400 so the line
+                still reads as "footer fine print" but actually clears WCAG AA
+                on the new #2A2A2A panel background. */}
             © 2026 Heritage Fire Vulnerability Assessment Tool · Franklin District
           </div>
         </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -73,7 +73,7 @@ const Login = () => {
               <div className="text-xs font-extrabold text-white uppercase tracking-widest leading-tight">
                 Heritage Fire<br />Vulnerability<br />Assessment Tool
               </div>
-              <div className="text-[11px] text-gray-300 mt-1">Franklin District · WA</div>
+              <div className="text-[11px] text-gray-400 mt-1">Franklin District · WA</div>
             </div>
           </div>
 
@@ -94,7 +94,7 @@ const Login = () => {
               with a left accent bar to give it visual weight without
               competing with the hero. */}
           <div className="mt-8 pl-4 border-l-2 border-[#8B2020]">
-            <div className="text-[10px] font-bold tracking-widest uppercase text-gray-300 mb-2">
+            <div className="text-[10px] font-bold tracking-widest uppercase text-gray-400 mb-2">
               Acknowledgement of Country
             </div>
             <p className="text-xs italic text-gray-300 leading-relaxed">
@@ -167,7 +167,7 @@ const Login = () => {
         <div>
           {/* Project Partners */}
           <div className="mb-6">
-            <div className="text-[10px] font-bold tracking-widest uppercase text-gray-300 mb-2">
+            <div className="text-[10px] font-bold tracking-widest uppercase text-gray-400 mb-2">
               Project Partners
             </div>
             <div className="space-y-2">
@@ -179,7 +179,7 @@ const Login = () => {
                 />
                 <div>
                   <div className="text-[11px] font-semibold text-white leading-tight">Wagyl Kaip</div>
-                  <div className="text-[10px] text-gray-300 leading-tight">Project Partner</div>
+                  <div className="text-[10px] text-gray-400 leading-tight">Project Partner</div>
                 </div>
               </div>
               <div className="flex items-center gap-2 rounded-md border border-[#3A3A3A] bg-[#303030] px-2 py-2">
@@ -190,7 +190,7 @@ const Login = () => {
                 />
                 <div>
                   <div className="text-[11px] font-semibold text-white leading-tight">University of Western Australia</div>
-                  <div className="text-[10px] text-gray-300 leading-tight">Project Partner</div>
+                  <div className="text-[10px] text-gray-400 leading-tight">Project Partner</div>
                 </div>
               </div>
             </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -77,10 +77,19 @@ const Login = () => {
             </div>
           </div>
 
-          {/* Hero */}
+          {/* Hero.
+              Broadened from "Aboriginal Heritage" to "Heritage Sites"
+              per client feedback ("it is not just Aboriginal heritage —
+              it is ALL heritage"). The tool ingests Aboriginal,
+              non-Aboriginal, and state-listed heritage places (see the
+              Heritage Registry and Risk Map filters), so the hero now
+              describes the actual scope. The Acknowledgement of Country
+              block below is intentionally unchanged — it is a cultural
+              recognition of the Wagyl Kaip Noongar Traditional
+              Custodians and is separate from the tool's data scope. */}
           <h1 className="text-4xl font-black text-white leading-tight tracking-tight mb-4">
             Protecting<br />
-            <span className="text-[#8B2020]">Aboriginal Heritage</span><br />
+            <span className="text-[#8B2020]">Heritage Sites</span><br />
             from Fire Risk
           </h1>
           <p className="text-sm text-gray-300 leading-relaxed">

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -42,15 +42,20 @@ const Login = () => {
     <div className="grid grid-cols-2 min-h-screen">
 
       {/* LEFT — branding.
-          Panel background lifted from #1A1A1A to #2A2A2A per client
-          feedback ("the black background makes some of the text hard
-          to read"). The shift keeps the dark, sidebar-style brand
-          feel but raises body-text contrast above the WCAG AA 4.5:1
-          threshold when paired with the lighter gray text classes
-          used below. Inner cards/borders are bumped proportionally
-          (#303030 / #3A3A3A) to preserve the subtle "elevated card"
-          relationship the sidebar uses (#202020 on #1A1A1A). */}
-      <div className="bg-[#2A2A2A] px-12 py-12 flex flex-col justify-between">
+          Panel background lifted from #1A1A1A -> #2A2A2A -> #3A3A3A
+          across two rounds of client readability feedback ("the black
+          background makes some of the text hard to read", then "still
+          not legible enough"). The dark, sidebar-aligned brand feel is
+          preserved, but the panel is now light enough that the eye
+          does not have to fight a near-black surface. Inner cards
+          (#454545) and borders (#555555) are bumped in step so the
+          "elevated card on dark panel" relationship is kept. Text
+          colours below are raised one tier in tandem (gray-300 ->
+          gray-200 for body, gray-400 -> gray-300 for eyebrow / caption
+          / footer) because lifting the panel alone would have lowered
+          contrast for any text class left unchanged. All combinations
+          clear WCAG AA 4.5:1 on the new panel. */}
+      <div className="bg-[#3A3A3A] px-12 py-12 flex flex-col justify-between">
         <div>
           {/* Brand */}
           <div className="flex items-start gap-3 mb-12">
@@ -73,7 +78,7 @@ const Login = () => {
               <div className="text-xs font-extrabold text-white uppercase tracking-widest leading-tight">
                 Heritage Fire<br />Vulnerability<br />Assessment Tool
               </div>
-              <div className="text-[11px] text-gray-400 mt-1">Franklin District · WA</div>
+              <div className="text-[11px] text-gray-300 mt-1">Franklin District · WA</div>
             </div>
           </div>
 
@@ -92,7 +97,7 @@ const Login = () => {
             <span className="text-[#8B2020]">Heritage Sites</span><br />
             from Fire Risk
           </h1>
-          <p className="text-sm text-gray-300 leading-relaxed">
+          <p className="text-sm text-gray-200 leading-relaxed">
             A web-based tool for land managers, indigenous rangers,
             and heritage practitioners in the Franklin District, Western Australia.
           </p>
@@ -103,10 +108,10 @@ const Login = () => {
               with a left accent bar to give it visual weight without
               competing with the hero. */}
           <div className="mt-8 pl-4 border-l-2 border-[#8B2020]">
-            <div className="text-[10px] font-bold tracking-widest uppercase text-gray-400 mb-2">
+            <div className="text-[10px] font-bold tracking-widest uppercase text-gray-300 mb-2">
               Acknowledgement of Country
             </div>
-            <p className="text-xs italic text-gray-300 leading-relaxed">
+            <p className="text-xs italic text-gray-200 leading-relaxed">
               We acknowledge the Wagyl Kaip Noongar people as the Traditional
               Custodians of the Franklin District, and pay our respects to
               Elders past and present. We recognise their enduring connection
@@ -123,7 +128,7 @@ const Login = () => {
             ].map((item) => (
               <div key={item} className="flex items-center gap-3">
                 <div className="w-2 h-2 rounded-full bg-[#8B2020] flex-shrink-0" />
-                <span className="text-xs text-gray-300">{item}</span>
+                <span className="text-xs text-gray-200">{item}</span>
               </div>
             ))}
           </div>
@@ -133,7 +138,7 @@ const Login = () => {
               disabled so users can read the location at a glance without
               accidentally panning/zooming. */}
           <div
-            className="mt-8 rounded-md overflow-hidden border border-[#3A3A3A]"
+            className="mt-8 rounded-md overflow-hidden border border-[#555555]"
             style={{ height: 200 }}
           >
             <MapContainer
@@ -176,11 +181,11 @@ const Login = () => {
         <div>
           {/* Project Partners */}
           <div className="mb-6">
-            <div className="text-[10px] font-bold tracking-widest uppercase text-gray-400 mb-2">
+            <div className="text-[10px] font-bold tracking-widest uppercase text-gray-300 mb-2">
               Project Partners
             </div>
             <div className="space-y-2">
-              <div className="flex items-center gap-2 rounded-md border border-[#3A3A3A] bg-[#303030] px-2 py-2">
+              <div className="flex items-center gap-2 rounded-md border border-[#555555] bg-[#454545] px-2 py-2">
                 <img
                   src="https://images.squarespace-cdn.com/content/v1/61f8e2c584741255f5ca8798/290d1715-85eb-4c72-a7e6-9c59ca2501ca/WKSNLogo.png"
                   alt="Wagyl Kaip South Noongar logo"
@@ -188,10 +193,10 @@ const Login = () => {
                 />
                 <div>
                   <div className="text-[11px] font-semibold text-white leading-tight">Wagyl Kaip</div>
-                  <div className="text-[10px] text-gray-400 leading-tight">Project Partner</div>
+                  <div className="text-[10px] text-gray-300 leading-tight">Project Partner</div>
                 </div>
               </div>
-              <div className="flex items-center gap-2 rounded-md border border-[#3A3A3A] bg-[#303030] px-2 py-2">
+              <div className="flex items-center gap-2 rounded-md border border-[#555555] bg-[#454545] px-2 py-2">
                 <img
                   src="https://www.uwa.edu.au/_assets/favicon512.png"
                   alt="University of Western Australia logo"
@@ -199,7 +204,7 @@ const Login = () => {
                 />
                 <div>
                   <div className="text-[11px] font-semibold text-white leading-tight">University of Western Australia</div>
-                  <div className="text-[10px] text-gray-400 leading-tight">Project Partner</div>
+                  <div className="text-[10px] text-gray-300 leading-tight">Project Partner</div>
                 </div>
               </div>
             </div>
@@ -210,17 +215,19 @@ const Login = () => {
               the tool follows, and the conditions of use. Logos are not
               repeated here because they already appear in the Project
               Partners cards above. */}
-          <div className="text-[11px] text-gray-300 leading-relaxed mb-4">
+          <div className="text-[11px] text-gray-200 leading-relaxed mb-4">
             <p>Developed with Wagyl Kaip and The University of Western Australia.</p>
             <p>This tool respects ICIP and IDaS principles.</p>
             <p>For authorised research/project use only. Do not misuse, redistribute, or expose sensitive heritage data.</p>
           </div>
 
-          <div className="text-xs text-gray-400">
+          <div className="text-xs text-gray-300">
             {/* Footer copyright line — keep brand string in sync with sidebar/title.
-                Colour bumped from text-gray-700 to text-gray-400 so the line
-                still reads as "footer fine print" but actually clears WCAG AA
-                on the new #2A2A2A panel background. */}
+                Colour bumped from text-gray-700 -> text-gray-400 -> text-gray-300
+                across the readability rework. Still reads as "footer fine print"
+                because the surrounding body text is now text-gray-200, but the
+                absolute luminance is high enough to be legible on the lifted
+                #3A3A3A panel. */}
             © 2026 Heritage Fire Vulnerability Assessment Tool · Franklin District
           </div>
         </div>


### PR DESCRIPTION
#### 1. Description

This PR addresses direct client feedback regarding the login page through two main tracks of improvements:

1. **UI Accessibility & Contrast**: Progressively lifted the dark left-panel baseline color scheme and overhauled the text classes across two iterative passes. All text components on the panel now fully satisfy **WCAG AA 4.5:1 contrast ratios** while maintaining a refined "dark-mode sidebar" visual hierarchy.
2. **Copywriting & Scope Alignment**: Broadened the hero panel terminology from *"Aboriginal Heritage"* to *"Heritage Sites"*. This copy update correctly aligns the login screen with the system's actual data ingestion scope, backend filter enums, and underlying risk models (which map both Aboriginal and Non-Aboriginal parameters).

The right-hand form panel (`#F0EDEB`) remains completely unchanged.

---

#### 2. Type of Change

* [x] **Bug Fix / UI Tuning**: Resolved accessibility/legibility blockerrs based on iterative client feedback.
* [x] **Content / Scope Alignment**: Broadened landing terminology to match existing underlying data structures.

---

#### 3. Detailed Commit Breakdown

1. **fix(login): lift left-panel background and restore two-tier text hierarchy** `862e418`
* **Background Pass 1**: Lifted the panel background color from `#1A1A1A` to `#2A2A2A` to make it less oppressive while retaining the dark sidebar style. Inner cards were shifted from `#202020` to `#303030` (border from `#2A2A2A` to `#3A3A3A`) to protect the relative elevation contrast relationship.
* **Text Contrast Pass 1**: Replaced old `text-gray-500/600/700` colors (which failed AA 4.5:1 against the dark background) with a strict, two-tier WCAG-compliant hierarchy:
* *Primary body text* (Hero description, Acknowledgement, bullets, ICIP/IDaS paragraph): `text-gray-300` (~9:1 ratio).
* *Secondary / Eyebrow text* (District/State labels, card captions, footer): `text-gray-400` (~5.4:1 ratio).




2. **fix(login): broaden hero from 'Aboriginal Heritage' to 'Heritage Sites'** `d4f70b9`
* Updated the login hero span from *"Aboriginal Heritage"* to *"Heritage Sites"* based on client clarification that the tool's true scope encompasses **all** heritage parameters.
* This aligns the frontend landing page with existing system realities: the backend data pipelines already ingest both the Aboriginal Cultural Heritage datasets (`DPLH 099 / 100`) and the State Heritage Register (`DPLH 006`), utilizing a two-value discriminator (`Aboriginal / Non-Aboriginal`) across the backend loader, modals, risk maps, and test assertions.
* Data sensitivity warnings regarding protected coordinates in the `README.md` and `DATA_MODEL_DOCS.md` remain strictly accurate and unchanged.


3. **fix(login): further lift panel and brighten text after second-pass feedback** `75be25a`
* **Background Pass 2**: Following a second review flight indicating the background was still slightly too dark for optimal readability, the panel scheme was notched up once further into the light. Left panel background stepped from `#2A2A2A` to `#3A3A3A`; inner cards shifted from `#303030` to `#454545` (border to `#555555`).
* **Text Contrast Pass 2**: Shifted text classes upward in lockstep with the panel to avoid any contrast reduction:
* *Primary body text* stepped up from `text-gray-300` to `text-gray-200` (~8.7:1 ratio on `#3A3A3A`).
* *Secondary text* stepped up from `text-gray-400` to `text-gray-300` (~7:1 ratio on `#3A3A3A`).


* The double-tier visual weight balance (Body vs. Eyebrow) is fully preserved.



---

#### 4. Verification & Compliance

* **Accessibility**: Every text element in the left-hand hero area now meets or exceeds the **WCAG AA 4.5:1 contrast minimum**.
* **Visuals**: Relative elevation boundaries (inner card vs. parent panel) and semantic font weight distributions are perfectly preserved across the lighter background tokens.
* **Terminology**: No changes made to sensitive data handling protocols; copy changes strictly ensure broader descriptive accuracy.

<img width="956" height="519" alt="image" src="https://github.com/user-attachments/assets/91e7bb12-2ff2-4206-a96f-12d12a902ab7" />
<img width="1915" height="98" alt="image" src="https://github.com/user-attachments/assets/ac8ea781-a1a4-4f56-aebf-8d3617790e1f" />
