### PR TITLE
feat(local-contacts): replace Perth HQ with DBCA Albany office

### DIFF
--- a/src/pages/LocalContacts.tsx
+++ b/src/pages/LocalContacts.tsx
@@ -115,15 +115,22 @@ const contactSections: ReadonlyArray<ContactSection> = [
     entries: [
       // DBCA Albany office — Parks and Wildlife Service, South Coast
       // Region. Added per client feedback ("Contact should have DBCA
-      // Albany"). Listed before the Perth headquarters because this
+      // Albany"). This is the only DBCA contact surfaced because the
       // tool is Franklin-District-specific and the South Coast Region
       // is the team that actually runs prescribed burns and on-ground
-      // conservation across Albany / Mt Barker / Denmark. Users calling
-      // about heritage fire context reach the right people faster by
-      // going through Albany first. Contact details verified via the
-      // public Google Maps listing for "DBCA's Parks and Wildlife
-      // Service – South Coast Region", 120 Albany Hwy, Centennial Park
-      // WA 6330.
+      // conservation across Albany / Mt Barker / Denmark — users with
+      // a heritage-fire question reach the right people fastest by
+      // calling Albany directly. The Perth headquarters entry was
+      // removed in the same change to avoid two near-identical DBCA
+      // cards (same website, contact form, and "Today's burns" link
+      // as Albany, differing only by a general-enquiries phone number
+      // that just routes back out to regional offices). Users who do
+      // need to reach Perth HQ for policy / complaints can still find
+      // it from dbca.wa.gov.au below.
+      //
+      // Contact details verified via the public Google Maps listing
+      // for "DBCA's Parks and Wildlife Service – South Coast Region",
+      // 120 Albany Hwy, Centennial Park WA 6330.
       {
         kind: 'organisation',
         id: 'dbca-albany',
@@ -134,33 +141,6 @@ const contactSections: ReadonlyArray<ContactSection> = [
         phone: {
           number: '(08) 9842 4500',
           note: 'Albany office · Mon–Fri',
-        },
-        website: {
-          url: 'https://www.dbca.wa.gov.au',
-          display: 'dbca.wa.gov.au',
-        },
-        contactForm: {
-          url: 'https://www.dbca.wa.gov.au/contact-us',
-          display: 'dbca.wa.gov.au/contact-us',
-        },
-        relevantLinks: [
-          {
-            label: "Today's burns",
-            url: 'https://www.dbca.wa.gov.au/management/fire/prescribed-burning/todays-burns',
-            description: 'Current prescribed burn program updates',
-          },
-        ],
-      },
-      {
-        kind: 'organisation',
-        id: 'dbca',
-        orgName:
-          'Department of Biodiversity, Conservation and Attractions',
-        affiliation: 'Government of Western Australia',
-        badgeLabel: 'Government Agency',
-        phone: {
-          number: '(08) 9219 9000',
-          note: 'General enquiries · Mon–Fri',
         },
         website: {
           url: 'https://www.dbca.wa.gov.au',

--- a/src/pages/LocalContacts.tsx
+++ b/src/pages/LocalContacts.tsx
@@ -113,6 +113,44 @@ const contactSections: ReadonlyArray<ContactSection> = [
     id: 'government-regulatory',
     heading: 'Government & Regulatory',
     entries: [
+      // DBCA Albany office — Parks and Wildlife Service, South Coast
+      // Region. Added per client feedback ("Contact should have DBCA
+      // Albany"). Listed before the Perth headquarters because this
+      // tool is Franklin-District-specific and the South Coast Region
+      // is the team that actually runs prescribed burns and on-ground
+      // conservation across Albany / Mt Barker / Denmark. Users calling
+      // about heritage fire context reach the right people faster by
+      // going through Albany first. Contact details verified via the
+      // public Google Maps listing for "DBCA's Parks and Wildlife
+      // Service – South Coast Region", 120 Albany Hwy, Centennial Park
+      // WA 6330.
+      {
+        kind: 'organisation',
+        id: 'dbca-albany',
+        orgName:
+          "DBCA's Parks and Wildlife Service – South Coast Region",
+        affiliation: 'Government of Western Australia · Albany',
+        badgeLabel: 'Parks & Wildlife · Albany',
+        phone: {
+          number: '(08) 9842 4500',
+          note: 'Albany office · Mon–Fri',
+        },
+        website: {
+          url: 'https://www.dbca.wa.gov.au',
+          display: 'dbca.wa.gov.au',
+        },
+        contactForm: {
+          url: 'https://www.dbca.wa.gov.au/contact-us',
+          display: 'dbca.wa.gov.au/contact-us',
+        },
+        relevantLinks: [
+          {
+            label: "Today's burns",
+            url: 'https://www.dbca.wa.gov.au/management/fire/prescribed-burning/todays-burns',
+            description: 'Current prescribed burn program updates',
+          },
+        ],
+      },
       {
         kind: 'organisation',
         id: 'dbca',


### PR DESCRIPTION
## Summary

Surface the DBCA office that actually services Franklin District on the
Local Contacts page, and remove the Perth headquarters card it had
been standing in for.

## Motivation

Client feedback during the 18 May 2026 review:

> Contact should have DBCA Albany

The Local Contacts page was sending users to the Perth head office by
default, which is not the team that runs prescribed burns or on-ground
conservation work in the Franklin District (Albany / Mt Barker /
Denmark). Callers from the project's actual user base — land managers,
indigenous rangers, heritage practitioners — would be transferred out
to a regional office anyway, so the HQ card was costing them a phone
hop without adding information.

## Changes

### Added
- **DBCA's Parks and Wildlife Service – South Coast Region** as the
  sole DBCA entry under *Government & Regulatory*.
  - Phone: `(08) 9842 4500` (Albany prefix)
  - Address (in source comment for traceability): 120 Albany Hwy,
    Centennial Park WA 6330
  - Website: `dbca.wa.gov.au`
  - Contact form: `dbca.wa.gov.au/contact-us`
  - Relevant link: *Today's burns* prescribed-burn schedule (statewide
    page, covers South Coast)
- Source comment explaining why this is the only DBCA contact shown
  and where to find Perth HQ if it is genuinely needed.

### Removed
- The previous *Department of Biodiversity, Conservation and
  Attractions* HQ entry (Perth, `(08) 9219 9000`).
  - Four of its five surfaced fields (website, contact form, "Today's
    burns", agency type) were identical to the new Albany entry, so
    keeping both produced two near-duplicate cards differing only in
    phone number.
  - Users who do need Perth HQ (policy, complaints) can reach it from
    the `dbca.wa.gov.au` link on the Albany card.

### Not changed
- `OrganisationContact` type and `OrganisationCard` component are
  untouched — the new entry fits the existing schema as-is.
- Page renderer is unchanged. It already switches a section to a
  centred single-column layout (`md:max-w-lg md:mx-auto`) when it has
  exactly one entry, so the Albany card centres itself once Perth is
  removed.
- Project Team section (Sean Winter, Sven Ouzman) is untouched.

## Files changed

- `src/pages/LocalContacts.tsx`

## Verification

- Visual check that the Albany card renders centred on wide screens
  (single-entry branch of the renderer's grid-class ternary).
- Click-through on phone (`tel:` href), website, contact form, and
  *Today's burns* link from the rendered card.
- TypeScript compiles — no `OrganisationContact` field added or
  removed, so no type drift downstream.

## Screenshots

| Before | After |
| --- | --- |
| _Government & Regulatory section showing single Perth HQ card_ | _Government & Regulatory section showing single Albany card_ |

_(Please attach screenshots when reviewing — the layout change is the
main user-visible effect.)_

## Source verification

Contact details for the new entry were verified against the public
Google Maps listing for "DBCA's Parks and Wildlife Service – South
Coast Region" at 120 Albany Hwy, Centennial Park WA 6330. No internal
DBCA directory was used.

## Follow-ups (out of scope for this PR)

- If the DBCA website ever publishes a stable South Coast Region
  landing page (e.g. `dbca.wa.gov.au/parks-and-wildlife-service/regions/south-coast`),
  swap the website URL on the Albany card to that more specific page.
- If we want to support a street address on organisation cards (for
  in-person visits), the `OrganisationContact` type and
  `OrganisationCard` component would need a new optional `address`
  field. Deferred — not requested in this round of feedback.

## Related

- Client feedback session: 18 May 2026
- Linked feedback items: *Contact should have DBCA Albany* (this PR)
- Sibling branch on the same review: `clientfb/login/180526` (login
  page readability + "Aboriginal Heritage" → "Heritage Sites" rewording)
<img width="1914" height="948" alt="image" src="https://github.com/user-attachments/assets/bfff4e29-3d0a-499f-aa8f-4e5954d17801" />
