### PR TITLE
style(login): polish login page – gradients, shadows, input icons, ac…

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -54,8 +54,21 @@ const Login = () => {
           gray-200 for body, gray-400 -> gray-300 for eyebrow / caption
           / footer) because lifting the panel alone would have lowered
           contrast for any text class left unchanged. All combinations
-          clear WCAG AA 4.5:1 on the new panel. */}
-      <div className="bg-[#3A3A3A] px-12 py-12 flex flex-col justify-between">
+          clear WCAG AA 4.5:1 on the new panel.
+          A 135-degree linear gradient is layered on top of the base
+          colour for a subtle sense of depth — slightly lighter at the
+          top-left where the brand logo and hero sit, fading to slightly
+          darker at the bottom-right. The tonal range is intentionally
+          small (#404040 -> #2F2F2F) so contrast against text is still
+          dominated by the mid-grey middle stop and the AA calculations
+          above still hold. */}
+      <div
+        className="px-12 py-12 flex flex-col justify-between"
+        style={{
+          background:
+            'linear-gradient(135deg, #404040 0%, #3A3A3A 55%, #2F2F2F 100%)',
+        }}
+      >
         <div>
           {/* Brand */}
           <div className="flex items-start gap-3 mb-12">
@@ -97,6 +110,15 @@ const Login = () => {
             <span className="text-[#8B2020]">Heritage Sites</span><br />
             from Fire Risk
           </h1>
+          {/* Short red accent bar visually separates the hero from the
+              body copy below and ties the hero to the brand red used on
+              the logo container, the Acknowledgement of Country quote
+              bar, and the feature-bullet dots. Width is intentionally
+              short so it reads as an accent, not a divider. */}
+          <div
+            className="w-14 h-1 rounded-full mb-5 bg-[#8B2020]"
+            aria-hidden="true"
+          />
           <p className="text-sm text-gray-200 leading-relaxed">
             A web-based tool for land managers, indigenous rangers,
             and heritage practitioners in the Franklin District, Western Australia.
@@ -185,7 +207,7 @@ const Login = () => {
               Project Partners
             </div>
             <div className="space-y-2">
-              <div className="flex items-center gap-2 rounded-md border border-[#555555] bg-[#454545] px-2 py-2">
+              <div className="flex items-center gap-2 rounded-md border border-[#555555] bg-[#454545] px-2 py-2 hover:bg-[#505050] hover:border-[#666666] transition-colors duration-200">
                 <img
                   src="https://images.squarespace-cdn.com/content/v1/61f8e2c584741255f5ca8798/290d1715-85eb-4c72-a7e6-9c59ca2501ca/WKSNLogo.png"
                   alt="Wagyl Kaip South Noongar logo"
@@ -196,7 +218,7 @@ const Login = () => {
                   <div className="text-[10px] text-gray-300 leading-tight">Project Partner</div>
                 </div>
               </div>
-              <div className="flex items-center gap-2 rounded-md border border-[#555555] bg-[#454545] px-2 py-2">
+              <div className="flex items-center gap-2 rounded-md border border-[#555555] bg-[#454545] px-2 py-2 hover:bg-[#505050] hover:border-[#666666] transition-colors duration-200">
                 <img
                   src="https://www.uwa.edu.au/_assets/favicon512.png"
                   alt="University of Western Australia logo"
@@ -233,52 +255,110 @@ const Login = () => {
         </div>
       </div>
 
-      {/* RIGHT — login form */}
-      <div className="flex items-center justify-center px-12 py-12" style={{ background: '#F0EDE8' }}>
-        <div className="bg-white rounded-2xl border border-gray-100 p-9 w-full max-w-sm">
+      {/* RIGHT — login form.
+          Background is a soft radial gradient so the cream panel has
+          a faint pool of light around the centre where the form sits,
+          instead of looking like a flat colour block. Form card is
+          lifted with shadow-2xl so it visibly hovers over the cream
+          surface — combined with the left panel's gradient this gives
+          the page a clear figure-vs-ground rhythm without changing
+          the underlying two-column layout. */}
+      <div
+        className="flex items-center justify-center px-12 py-12"
+        style={{
+          background:
+            'radial-gradient(ellipse at center, #F5F2EC 0%, #F0EDE8 55%, #E8E3DA 100%)',
+        }}
+      >
+        <div className="bg-white rounded-2xl shadow-2xl shadow-black/5 border border-gray-100 p-9 w-full max-w-sm">
+          {/* Small accent dot above the heading echoes the red bar on
+              the hero side, tying the two halves of the page together
+              without competing with the form. */}
+          <div
+            className="w-8 h-1 rounded-full bg-[#8B2020] mb-3"
+            aria-hidden="true"
+          />
           <h2 className="text-xl font-black text-gray-900 mb-1">Welcome back</h2>
-          <p className="text-sm text-gray-400 mb-7">Sign in to your account to continue</p>
+          <p className="text-sm text-gray-500 mb-7">Sign in to your account to continue</p>
 
           <form onSubmit={handleSubmit} noValidate>
-            {/* Email */}
+            {/* Email — input has a leading envelope icon (absolute
+                positioned inside a relative wrapper) so the field
+                reads as "email" without relying solely on the label
+                above. Input gets pl-10 to clear the icon. */}
             <div className="mb-4">
               <label htmlFor="login-email" className="block text-xs font-bold text-gray-500 mb-1.5 tracking-wide">
                 Email address
               </label>
-              <input
-                id="login-email"
-                type="email"
-                autoComplete="email"
-                required
-                disabled={loading}
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="you@dpird.wa.gov.au"
-                className="w-full px-4 py-3 border border-gray-100 rounded-xl text-sm text-gray-900 bg-gray-50 outline-none focus:border-gray-300 focus:bg-white transition-colors disabled:opacity-60"
-              />
+              <div className="relative">
+                <svg
+                  className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+                  <polyline points="22,6 12,13 2,6" />
+                </svg>
+                <input
+                  id="login-email"
+                  type="email"
+                  autoComplete="email"
+                  required
+                  disabled={loading}
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="you@dpird.wa.gov.au"
+                  className="w-full pl-10 pr-4 py-3 border border-gray-100 rounded-xl text-sm text-gray-900 bg-gray-50 outline-none focus:border-gray-300 focus:bg-white transition-colors disabled:opacity-60"
+                />
+              </div>
             </div>
 
-            {/* Password */}
+            {/* Password — same leading-icon treatment as the email
+                field, swapped for a padlock so the field type is
+                obvious even when the bullets in the placeholder are
+                a bit subtle. */}
             <div className="mb-2">
               <label htmlFor="login-password" className="block text-xs font-bold text-gray-500 mb-1.5 tracking-wide">
                 Password
               </label>
-              <input
-                id="login-password"
-                type="password"
-                autoComplete="current-password"
-                required
-                disabled={loading}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="••••••••"
-                className="w-full px-4 py-3 border border-gray-100 rounded-xl text-sm text-gray-900 bg-gray-50 outline-none focus:border-gray-300 focus:bg-white transition-colors disabled:opacity-60"
-              />
+              <div className="relative">
+                <svg
+                  className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                  <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                </svg>
+                <input
+                  id="login-password"
+                  type="password"
+                  autoComplete="current-password"
+                  required
+                  disabled={loading}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="••••••••"
+                  className="w-full pl-10 pr-4 py-3 border border-gray-100 rounded-xl text-sm text-gray-900 bg-gray-50 outline-none focus:border-gray-300 focus:bg-white transition-colors disabled:opacity-60"
+                />
+              </div>
             </div>
 
-            {/* Forgot */}
+            {/* Forgot password — colour bumped from gray-400 to
+                gray-500 for AA compliance on white. Still reads as
+                "secondary" because of the size and weight. */}
             <div className="text-right mb-6">
-              <span className="text-xs text-gray-400 cursor-pointer hover:text-gray-600 transition-colors">
+              <span className="text-xs text-gray-500 cursor-pointer hover:text-[#8B2020] hover:underline transition-colors">
                 Forgot password?
               </span>
             </div>
@@ -293,11 +373,19 @@ const Login = () => {
               </div>
             )}
 
-            {/* Sign in btn */}
+            {/* Sign in btn — uses a subtle gradient instead of a flat
+                black so it has a touch more depth, and a shadow that
+                grows slightly on hover for a tactile cue. Colour stays
+                in the near-black family so the form's accent hierarchy
+                (red bar > black button > everything else) is preserved. */}
             <button
               type="submit"
               disabled={loading}
-              className="w-full bg-[#1A1A1A] text-white py-3 rounded-xl text-sm font-black hover:bg-gray-800 transition-colors mb-3 disabled:opacity-60 disabled:cursor-not-allowed"
+              className="w-full text-white py-3 rounded-xl text-sm font-black mb-3 shadow-md hover:shadow-lg hover:-translate-y-px transition-all duration-200 disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:translate-y-0"
+              style={{
+                background:
+                  'linear-gradient(180deg, #2A2A2A 0%, #1A1A1A 100%)',
+              }}
             >
               {loading ? 'Signing in…' : 'Sign in'}
             </button>
@@ -305,13 +393,16 @@ const Login = () => {
 
           {/* Divider */}
           <div className="flex items-center gap-3 my-4">
-            <div className="flex-1 h-px bg-gray-100" />
-            <span className="text-xs text-gray-300 font-semibold">or</span>
-            <div className="flex-1 h-px bg-gray-100" />
+            <div className="flex-1 h-px bg-gray-200" />
+            <span className="text-[10px] text-gray-400 font-bold uppercase tracking-widest">or</span>
+            <div className="flex-1 h-px bg-gray-200" />
           </div>
 
-          {/* Microsoft btn */}
-          <button className="w-full py-3 rounded-xl text-sm font-bold text-gray-600 flex items-center justify-center gap-2 hover:bg-gray-100 transition-colors" style={{ background: '#F0EDE8' }}>
+          {/* Microsoft btn — now has a 1px border so it visually sits
+              as a real button on the cream-tinted background rather
+              than floating. Hover state lifts background to white for
+              a clear "pressable" cue. */}
+          <button className="w-full py-3 rounded-xl text-sm font-bold text-gray-700 flex items-center justify-center gap-2 border border-gray-200 hover:bg-white hover:border-gray-300 transition-colors" style={{ background: '#F7F4EE' }}>
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
               <rect x="1" y="1" width="6" height="6" rx="1" fill="#4A90D9"/>
               <rect x="9" y="1" width="6" height="6" rx="1" fill="#4A90D9" opacity=".6"/>
@@ -321,10 +412,14 @@ const Login = () => {
             Sign in with Microsoft
           </button>
 
-          {/* Footer note */}
-          <p className="text-center text-xs text-gray-300 mt-6 leading-relaxed">
+          {/* Footer note — colour bumped from gray-300 to gray-500 so
+              the line clears WCAG AA on the form's white background
+              (gray-300 on white was ~1.6:1, well below the 4.5:1
+              threshold). "Create account" stays the strongest weight
+              so the call-to-action remains the focal point. */}
+          <p className="text-center text-xs text-gray-500 mt-6 leading-relaxed">
            Do not have an account?{' '}
-           <Link to="/register" className="font-bold text-gray-700 hover:text-gray-900">
+           <Link to="/register" className="font-bold text-gray-900 hover:text-[#8B2020] hover:underline transition-colors">
             Create account
            </Link>
            <br />


### PR DESCRIPTION
…cent bars

Visual-only pass; two-column structure, content, and logic unchanged.

Left panel

- Flat #3A3A3A → 135° gradient (#404040 → #2F2F2F); AA contrast preserved.

- Red accent bar (#8B2020) added between hero h1 and body copy.

- Partner cards get hover lift (bg #454545→#505050, border #555→#666).

Right panel

- Flat #F0EDE8 → radial gradient (#F5F2EC center → #E8E3DA edges).

- Form card: shadow-2xl to read as elevated.

- Small red accent bar above 'Welcome back' mirrors left panel hero bar.

- Inputs: leading icons (envelope/padlock) + pl-10 padding.

- Sign in button: flat → vertical gradient + shadow-md + 1px hover lift.

- OR divider: 10px uppercase, gray-300 → gray-400.

- Microsoft button: 1px border + hover-to-white state.

Contrast fixes

- Subtitle, forgot-password, footer: gray-400 → gray-500 (now ≥4.5:1 AA).

- Brand-red hover + underline on forgot-password and 'Create account'.

No new deps, no state/auth/routing changes. Register page unchanged.
<img width="1908" height="934" alt="image" src="https://github.com/user-attachments/assets/cd39cade-e576-457c-a83b-5ba8eb44916a" />
